### PR TITLE
Muscat ui elements

### DIFF
--- a/observation_portal/common/configdb.py
+++ b/observation_portal/common/configdb.py
@@ -368,6 +368,10 @@ class ConfigDB(object):
                 for optical_element_group in instrument['science_camera']['optical_element_groups']:
                     for element in optical_element_group['optical_elements']:
                         if element['code'] not in optical_elements_tracker[optical_element_group['type']]:
+                            if optical_element_group['default'].upper() == element['code'].upper():
+                                element['default'] = True
+                            else:
+                                element['default'] = False
                             optical_elements_tracker[optical_element_group['type']].add(element['code'])
                             optical_elements[optical_element_group['type']].append(element)
         return optical_elements

--- a/observation_portal/common/mixins.py
+++ b/observation_portal/common/mixins.py
@@ -40,3 +40,16 @@ class CustomIsoDateTimeFilterMixin(object):
             if isinstance(f, IsoDateTimeFilter):
                 f.field_class = CustomIsoDateTimeField
         return filters
+
+class ExtraParamsFormatter(object):
+    ''' This should be mixed in with Serializers that have extra_params JSON fields, to ensure the float values are 
+        stored as float values in the db instead of as strings
+    '''
+    def to_internal_value(self, data):
+        data = super().to_internal_value(data)
+        for field, value in data.get('extra_params', {}).items():
+            try:
+                data['extra_params'][field] = float(value)
+            except ValueError:
+                pass
+        return data

--- a/observation_portal/common/test_data/configdb.json
+++ b/observation_portal/common/test_data/configdb.json
@@ -144,7 +144,8 @@
                             "code": "air",
                             "schedulable": false
                           }
-                        ]
+                        ],
+                        "default": "air"
                       }
                     ]
                   },
@@ -270,7 +271,8 @@
                             "code": "air",
                             "schedulable": false
                           }
-                        ]
+                        ],
+                        "default": "air"
                       }
                     ]
                   },
@@ -396,7 +398,8 @@
                             "code": "air",
                             "schedulable": false
                           }
-                        ]
+                        ],
+                        "default": "air"
                       }
                     ]
                   },
@@ -554,7 +557,8 @@
                             "code": "slit_1.2as",
                             "schedulable": true
                           }
-                        ]
+                        ],
+                        "default": "slit_1.6as"
                       }
                     ]
                   },
@@ -701,7 +705,8 @@
                             "code": "air",
                             "schedulable": false
                           }
-                        ]
+                        ],
+                        "default": "air"
                       }
                     ]
                   },
@@ -968,7 +973,8 @@
                             "code": "slit_1.2as",
                             "schedulable": true
                           }
-                        ]
+                        ],
+                        "default": "slit_1.6as"
                       }
                     ]
                   },
@@ -1115,7 +1121,8 @@
                             "code": "air",
                             "schedulable": false
                           }
-                        ]
+                        ],
+                        "default": "air"
                       }
                     ]
                   },

--- a/observation_portal/common/test_data/configdb.json
+++ b/observation_portal/common/test_data/configdb.json
@@ -979,7 +979,409 @@
                     ]
                   },
                   "__str__": "tst.domb.2m0a.xx02-xx02"
-                }
+                },
+                {
+                  "code": "mc03",
+                  "state": "SCHEDULABLE",
+                  "science_camera": {
+                      "code": "mc03",
+                      "camera_type": {
+                          "size": "26.4x26.4",
+                          "pscale": 1.0,
+                          "default_mode": {
+                              "id": 43,
+                              "binning": 1,
+                              "overhead": 10,
+                              "readout": 10.0
+                          },
+                          "name": "2.0 meter Muscat",
+                          "code": "2M0-SCICAM-MUSCAT",
+                          "mode_set": [
+                              {
+                                  "binning": 1,
+                                  "overhead": 10,
+                                  "readout": 10.0
+                              }
+                          ],
+                          "fixed_overhead_per_exposure": 1.0,
+                          "front_padding": 90.0,
+                          "filter_change_time": 0.0,
+                          "config_change_time": 0.0,
+                          "acquire_exposure_time": 0.0,
+                          "acquire_processing_time": 0.0,
+                          "mode_types": [
+                              {
+                                  "type": "acquisition",
+                                  "modes": [
+                                      {
+                                          "name": "Acquire Off",
+                                          "overhead": 0.0,
+                                          "code": "OFF",
+                                          "params": {}
+                                      }
+                                  ],
+                                  "default": "OFF"
+                              },
+                              {
+                                  "type": "readout",
+                                  "modes": [
+                                      {
+                                          "name": "Muscat Slow Readout",
+                                          "overhead": 10.0,
+                                          "code": "MUSCAT_SLOW",
+                                          "params": {
+                                              "binning": 1
+                                          }
+                                      }
+                                  ],
+                                  "default": "MUSCAT_SLOW"
+                              },
+                              {
+                                  "type": "exposure",
+                                  "modes": [
+                                      {
+                                          "name": "Muscat Synchronous Exposure Mode",
+                                          "overhead": 0.0,
+                                          "code": "SYNCHRONOUS",
+                                          "params": {
+                                              "required_fields": [
+                                                  "exposure_time_g",
+                                                  "exposure_time_r",
+                                                  "exposure_time_i",
+                                                  "exposure_time_z",
+                                                  "exposure_mode"
+                                              ]
+                                          }
+                                      },
+                                      {
+                                          "name": "Muscat Asynchronous Exposure Mode",
+                                          "overhead": 0.0,
+                                          "code": "ASYNCHRONOUS",
+                                          "params": {
+                                              "required_fields": [
+                                                  "exposure_time_g",
+                                                  "exposure_time_r",
+                                                  "exposure_time_i",
+                                                  "exposure_time_z",
+                                                  "exposure_mode"
+                                              ]
+                                          }
+                                      }
+                                  ],
+                                  "default": "SYNCHRONOUS"
+                              },
+                              {
+                                  "type": "guiding",
+                                  "modes": [
+                                      {
+                                          "name": "On",
+                                          "overhead": 0.0,
+                                          "code": "ON",
+                                          "params": {}
+                                      }
+                                  ],
+                                  "default": "ON"
+                              }
+                          ],
+                          "default_acceptability_threshold": 90.0,
+                          "pixels_x": 2048,
+                          "pixels_y": 2048,
+                          "max_rois": 0,
+                          "allow_self_guiding": true,
+                          "configuration_types": [
+                              "EXPOSE",
+                              "REPEAT_EXPOSE",
+                              "BIAS",
+                              "DARK",
+                              "STANDARD",
+                              "SCRIPT",
+                              "AUTO_FOCUS",
+                              "SKY_FLAT",
+                              "ENGINEERING"
+                          ]
+                      },
+                      "optical_elements": {
+                          "diffuser_g_positions": "in,out",
+                          "diffuser_r_positions": "in,out",
+                          "diffuser_i_positions": "in,out",
+                          "diffuser_z_positions": "in,out"
+                      },
+                      "optical_element_groups": [
+                          {
+                              "name": "Diffuser g'",
+                              "type": "diffuser_g_positions",
+                              "optical_elements": [
+                                  {
+                                      "name": "In Beam",
+                                      "code": "in",
+                                      "schedulable": true
+                                  },
+                                  {
+                                      "name": "Out of Beam",
+                                      "code": "out",
+                                      "schedulable": true
+                                  }
+                              ],
+                              "element_change_overhead": 0.0,
+                              "default": "out"
+                          },
+                          {
+                              "name": "Diffuser r'",
+                              "type": "diffuser_r_positions",
+                              "optical_elements": [
+                                  {
+                                      "name": "In Beam",
+                                      "code": "in",
+                                      "schedulable": true
+                                  },
+                                  {
+                                      "name": "Out of Beam",
+                                      "code": "out",
+                                      "schedulable": true
+                                  }
+                              ],
+                              "element_change_overhead": 0.0,
+                              "default": "out"
+                          },
+                          {
+                              "name": "Diffuser i'",
+                              "type": "diffuser_i_positions",
+                              "optical_elements": [
+                                  {
+                                      "name": "In Beam",
+                                      "code": "in",
+                                      "schedulable": true
+                                  },
+                                  {
+                                      "name": "Out of Beam",
+                                      "code": "out",
+                                      "schedulable": true
+                                  }
+                              ],
+                              "element_change_overhead": 0.0,
+                              "default": "out"
+                          },
+                          {
+                              "name": "Diffuser z'",
+                              "type": "diffuser_z_positions",
+                              "optical_elements": [
+                                  {
+                                      "name": "In Beam",
+                                      "code": "in",
+                                      "schedulable": true
+                                  },
+                                  {
+                                      "name": "Out of Beam",
+                                      "code": "out",
+                                      "schedulable": true
+                                  }
+                              ],
+                              "element_change_overhead": 0.0,
+                              "default": "out"
+                          }
+                      ]
+                  },
+                  "autoguider_camera": {
+                      "code": "mc03",
+                      "camera_type": {
+                          "id": 57,
+                          "size": "26.4x26.4",
+                          "pscale": 1.0,
+                          "default_mode": {
+                              "id": 43,
+                              "binning": 1,
+                              "overhead": 10,
+                              "readout": 10.0
+                          },
+                          "name": "2.0 meter Muscat",
+                          "code": "2M0-SCICAM-MUSCAT",
+                          "mode_set": [
+                              {
+                                  "binning": 1,
+                                  "overhead": 10,
+                                  "readout": 10.0
+                              }
+                          ],
+                          "fixed_overhead_per_exposure": 1.0,
+                          "front_padding": 90.0,
+                          "filter_change_time": 0.0,
+                          "config_change_time": 0.0,
+                          "acquire_exposure_time": 0.0,
+                          "acquire_processing_time": 0.0,
+                          "mode_types": [
+                              {
+                                  "type": "acquisition",
+                                  "modes": [
+                                      {
+                                          "name": "Acquire Off",
+                                          "overhead": 0.0,
+                                          "code": "OFF",
+                                          "params": {}
+                                      }
+                                  ],
+                                  "default": "OFF"
+                              },
+                              {
+                                  "type": "readout",
+                                  "modes": [
+                                      {
+                                          "name": "Muscat Slow Readout",
+                                          "overhead": 10.0,
+                                          "code": "MUSCAT_SLOW",
+                                          "params": {
+                                              "binning": 1
+                                          }
+                                      }
+                                  ],
+                                  "default": "MUSCAT_SLOW"
+                              },
+                              {
+                                  "type": "exposure",
+                                  "modes": [
+                                      {
+                                          "name": "Muscat Synchronous Exposure Mode",
+                                          "overhead": 0.0,
+                                          "code": "SYNCHRONOUS",
+                                          "params": {
+                                              "required_fields": [
+                                                  "exposure_time_g",
+                                                  "exposure_time_r",
+                                                  "exposure_time_i",
+                                                  "exposure_time_z",
+                                                  "exposure_mode"
+                                              ]
+                                          }
+                                      },
+                                      {
+                                          "name": "Muscat Asynchronous Exposure Mode",
+                                          "overhead": 0.0,
+                                          "code": "ASYNCHRONOUS",
+                                          "params": {
+                                              "required_fields": [
+                                                  "exposure_time_g",
+                                                  "exposure_time_r",
+                                                  "exposure_time_i",
+                                                  "exposure_time_z",
+                                                  "exposure_mode"
+                                              ]
+                                          }
+                                      }
+                                  ],
+                                  "default": "SYNCHRONOUS"
+                              },
+                              {
+                                  "type": "guiding",
+                                  "modes": [
+                                      {
+                                          "name": "On",
+                                          "overhead": 0.0,
+                                          "code": "ON",
+                                          "params": {}
+                                      }
+                                  ],
+                                  "default": "ON"
+                              }
+                          ],
+                          "default_acceptability_threshold": 90.0,
+                          "pixels_x": 2048,
+                          "pixels_y": 2048,
+                          "max_rois": 0,
+                          "allow_self_guiding": true,
+                          "configuration_types": [
+                              "EXPOSE",
+                              "REPEAT_EXPOSE",
+                              "BIAS",
+                              "DARK",
+                              "STANDARD",
+                              "SCRIPT",
+                              "AUTO_FOCUS",
+                              "SKY_FLAT",
+                              "ENGINEERING"
+                          ]
+                      },
+                      "optical_elements": {
+                          "diffuser_g_positions": "in,out",
+                          "diffuser_r_positions": "in,out",
+                          "diffuser_i_positions": "in,out",
+                          "diffuser_z_positions": "in,out"
+                      },
+                      "optical_element_groups": [
+                          {
+                              "name": "Diffuser g'",
+                              "type": "diffuser_g_positions",
+                              "optical_elements": [
+                                  {
+                                      "name": "In Beam",
+                                      "code": "in",
+                                      "schedulable": true
+                                  },
+                                  {
+                                      "name": "Out of Beam",
+                                      "code": "out",
+                                      "schedulable": true
+                                  }
+                              ],
+                              "element_change_overhead": 0.0,
+                              "default": "out"
+                          },
+                          {
+                              "name": "Diffuser r'",
+                              "type": "diffuser_r_positions",
+                              "optical_elements": [
+                                  {
+                                      "name": "In Beam",
+                                      "code": "in",
+                                      "schedulable": true
+                                  },
+                                  {
+                                      "name": "Out of Beam",
+                                      "code": "out",
+                                      "schedulable": true
+                                  }
+                              ],
+                              "element_change_overhead": 0.0,
+                              "default": "out"
+                          },
+                          {
+                              "name": "Diffuser i'",
+                              "type": "diffuser_i_positions",
+                              "optical_elements": [
+                                  {
+                                      "name": "In Beam",
+                                      "code": "in",
+                                      "schedulable": true
+                                  },
+                                  {
+                                      "name": "Out of Beam",
+                                      "code": "out",
+                                      "schedulable": true
+                                  }
+                              ],
+                              "element_change_overhead": 0.0,
+                              "default": "out"
+                          },
+                          {
+                              "name": "Diffuser z'",
+                              "type": "diffuser_z_positions",
+                              "optical_elements": [
+                                  {
+                                      "name": "In Beam",
+                                      "code": "in",
+                                      "schedulable": true
+                                  },
+                                  {
+                                      "name": "Out of Beam",
+                                      "code": "out",
+                                      "schedulable": true
+                                  }
+                              ],
+                              "element_change_overhead": 0.0,
+                              "default": "out"
+                          }
+                      ]
+                  },
+                  "__str__": "tst.domb.2m0a.mc03-mc03"
+              }
               ]
             }
           ]

--- a/observation_portal/common/test_data/configdb.json
+++ b/observation_portal/common/test_data/configdb.json
@@ -817,8 +817,7 @@
                       ]
                     },
                     "filters": "air",
-                    "optical_element_groups": [
-                    ]
+                    "optical_element_groups": []
                   },
                   "__str__": "tst.domb.1m0a.nres02-nres02"
                 }
@@ -984,404 +983,404 @@
                   "code": "mc03",
                   "state": "SCHEDULABLE",
                   "science_camera": {
-                      "code": "mc03",
-                      "camera_type": {
-                          "size": "26.4x26.4",
-                          "pscale": 1.0,
-                          "default_mode": {
-                              "id": 43,
-                              "binning": 1,
-                              "overhead": 10,
-                              "readout": 10.0
-                          },
-                          "name": "2.0 meter Muscat",
-                          "code": "2M0-SCICAM-MUSCAT",
-                          "mode_set": [
-                              {
-                                  "binning": 1,
-                                  "overhead": 10,
-                                  "readout": 10.0
-                              }
-                          ],
-                          "fixed_overhead_per_exposure": 1.0,
-                          "front_padding": 90.0,
-                          "filter_change_time": 0.0,
-                          "config_change_time": 0.0,
-                          "acquire_exposure_time": 0.0,
-                          "acquire_processing_time": 0.0,
-                          "mode_types": [
-                              {
-                                  "type": "acquisition",
-                                  "modes": [
-                                      {
-                                          "name": "Acquire Off",
-                                          "overhead": 0.0,
-                                          "code": "OFF",
-                                          "params": {}
-                                      }
-                                  ],
-                                  "default": "OFF"
-                              },
-                              {
-                                  "type": "readout",
-                                  "modes": [
-                                      {
-                                          "name": "Muscat Slow Readout",
-                                          "overhead": 10.0,
-                                          "code": "MUSCAT_SLOW",
-                                          "params": {
-                                              "binning": 1
-                                          }
-                                      }
-                                  ],
-                                  "default": "MUSCAT_SLOW"
-                              },
-                              {
-                                  "type": "exposure",
-                                  "modes": [
-                                      {
-                                          "name": "Muscat Synchronous Exposure Mode",
-                                          "overhead": 0.0,
-                                          "code": "SYNCHRONOUS",
-                                          "params": {
-                                              "required_fields": [
-                                                  "exposure_time_g",
-                                                  "exposure_time_r",
-                                                  "exposure_time_i",
-                                                  "exposure_time_z",
-                                                  "exposure_mode"
-                                              ]
-                                          }
-                                      },
-                                      {
-                                          "name": "Muscat Asynchronous Exposure Mode",
-                                          "overhead": 0.0,
-                                          "code": "ASYNCHRONOUS",
-                                          "params": {
-                                              "required_fields": [
-                                                  "exposure_time_g",
-                                                  "exposure_time_r",
-                                                  "exposure_time_i",
-                                                  "exposure_time_z",
-                                                  "exposure_mode"
-                                              ]
-                                          }
-                                      }
-                                  ],
-                                  "default": "SYNCHRONOUS"
-                              },
-                              {
-                                  "type": "guiding",
-                                  "modes": [
-                                      {
-                                          "name": "On",
-                                          "overhead": 0.0,
-                                          "code": "ON",
-                                          "params": {}
-                                      }
-                                  ],
-                                  "default": "ON"
-                              }
-                          ],
-                          "default_acceptability_threshold": 90.0,
-                          "pixels_x": 2048,
-                          "pixels_y": 2048,
-                          "max_rois": 0,
-                          "allow_self_guiding": true,
-                          "configuration_types": [
-                              "EXPOSE",
-                              "REPEAT_EXPOSE",
-                              "BIAS",
-                              "DARK",
-                              "STANDARD",
-                              "SCRIPT",
-                              "AUTO_FOCUS",
-                              "SKY_FLAT",
-                              "ENGINEERING"
-                          ]
+                    "code": "mc03",
+                    "camera_type": {
+                      "size": "26.4x26.4",
+                      "pscale": 1.0,
+                      "default_mode": {
+                        "id": 43,
+                        "binning": 1,
+                        "overhead": 10,
+                        "readout": 10.0
                       },
-                      "optical_elements": {
-                          "diffuser_g_positions": "in,out",
-                          "diffuser_r_positions": "in,out",
-                          "diffuser_i_positions": "in,out",
-                          "diffuser_z_positions": "in,out"
-                      },
-                      "optical_element_groups": [
-                          {
-                              "name": "Diffuser g'",
-                              "type": "diffuser_g_positions",
-                              "optical_elements": [
-                                  {
-                                      "name": "In Beam",
-                                      "code": "in",
-                                      "schedulable": true
-                                  },
-                                  {
-                                      "name": "Out of Beam",
-                                      "code": "out",
-                                      "schedulable": true
-                                  }
-                              ],
-                              "element_change_overhead": 0.0,
-                              "default": "out"
-                          },
-                          {
-                              "name": "Diffuser r'",
-                              "type": "diffuser_r_positions",
-                              "optical_elements": [
-                                  {
-                                      "name": "In Beam",
-                                      "code": "in",
-                                      "schedulable": true
-                                  },
-                                  {
-                                      "name": "Out of Beam",
-                                      "code": "out",
-                                      "schedulable": true
-                                  }
-                              ],
-                              "element_change_overhead": 0.0,
-                              "default": "out"
-                          },
-                          {
-                              "name": "Diffuser i'",
-                              "type": "diffuser_i_positions",
-                              "optical_elements": [
-                                  {
-                                      "name": "In Beam",
-                                      "code": "in",
-                                      "schedulable": true
-                                  },
-                                  {
-                                      "name": "Out of Beam",
-                                      "code": "out",
-                                      "schedulable": true
-                                  }
-                              ],
-                              "element_change_overhead": 0.0,
-                              "default": "out"
-                          },
-                          {
-                              "name": "Diffuser z'",
-                              "type": "diffuser_z_positions",
-                              "optical_elements": [
-                                  {
-                                      "name": "In Beam",
-                                      "code": "in",
-                                      "schedulable": true
-                                  },
-                                  {
-                                      "name": "Out of Beam",
-                                      "code": "out",
-                                      "schedulable": true
-                                  }
-                              ],
-                              "element_change_overhead": 0.0,
-                              "default": "out"
-                          }
+                      "name": "2.0 meter Muscat",
+                      "code": "2M0-SCICAM-MUSCAT",
+                      "mode_set": [
+                        {
+                          "binning": 1,
+                          "overhead": 10,
+                          "readout": 10.0
+                        }
+                      ],
+                      "fixed_overhead_per_exposure": 1.0,
+                      "front_padding": 90.0,
+                      "filter_change_time": 0.0,
+                      "config_change_time": 0.0,
+                      "acquire_exposure_time": 0.0,
+                      "acquire_processing_time": 0.0,
+                      "mode_types": [
+                        {
+                          "type": "acquisition",
+                          "modes": [
+                            {
+                              "name": "Acquire Off",
+                              "overhead": 0.0,
+                              "code": "OFF",
+                              "params": {}
+                            }
+                          ],
+                          "default": "OFF"
+                        },
+                        {
+                          "type": "readout",
+                          "modes": [
+                            {
+                              "name": "Muscat Slow Readout",
+                              "overhead": 10.0,
+                              "code": "MUSCAT_SLOW",
+                              "params": {
+                                "binning": 1
+                              }
+                            }
+                          ],
+                          "default": "MUSCAT_SLOW"
+                        },
+                        {
+                          "type": "exposure",
+                          "modes": [
+                            {
+                              "name": "Muscat Synchronous Exposure Mode",
+                              "overhead": 0.0,
+                              "code": "SYNCHRONOUS",
+                              "params": {
+                                "required_fields": [
+                                  "exposure_time_g",
+                                  "exposure_time_r",
+                                  "exposure_time_i",
+                                  "exposure_time_z",
+                                  "exposure_mode"
+                                ]
+                              }
+                            },
+                            {
+                              "name": "Muscat Asynchronous Exposure Mode",
+                              "overhead": 0.0,
+                              "code": "ASYNCHRONOUS",
+                              "params": {
+                                "required_fields": [
+                                  "exposure_time_g",
+                                  "exposure_time_r",
+                                  "exposure_time_i",
+                                  "exposure_time_z",
+                                  "exposure_mode"
+                                ]
+                              }
+                            }
+                          ],
+                          "default": "SYNCHRONOUS"
+                        },
+                        {
+                          "type": "guiding",
+                          "modes": [
+                            {
+                              "name": "On",
+                              "overhead": 0.0,
+                              "code": "ON",
+                              "params": {}
+                            }
+                          ],
+                          "default": "ON"
+                        }
+                      ],
+                      "default_acceptability_threshold": 90.0,
+                      "pixels_x": 2048,
+                      "pixels_y": 2048,
+                      "max_rois": 0,
+                      "allow_self_guiding": true,
+                      "configuration_types": [
+                        "EXPOSE",
+                        "REPEAT_EXPOSE",
+                        "BIAS",
+                        "DARK",
+                        "STANDARD",
+                        "SCRIPT",
+                        "AUTO_FOCUS",
+                        "SKY_FLAT",
+                        "ENGINEERING"
                       ]
+                    },
+                    "optical_elements": {
+                      "diffuser_g_positions": "in,out",
+                      "diffuser_r_positions": "in,out",
+                      "diffuser_i_positions": "in,out",
+                      "diffuser_z_positions": "in,out"
+                    },
+                    "optical_element_groups": [
+                      {
+                        "name": "Diffuser g'",
+                        "type": "diffuser_g_positions",
+                        "optical_elements": [
+                          {
+                            "name": "In Beam",
+                            "code": "in",
+                            "schedulable": true
+                          },
+                          {
+                            "name": "Out of Beam",
+                            "code": "out",
+                            "schedulable": true
+                          }
+                        ],
+                        "element_change_overhead": 0.0,
+                        "default": "out"
+                      },
+                      {
+                        "name": "Diffuser r'",
+                        "type": "diffuser_r_positions",
+                        "optical_elements": [
+                          {
+                            "name": "In Beam",
+                            "code": "in",
+                            "schedulable": true
+                          },
+                          {
+                            "name": "Out of Beam",
+                            "code": "out",
+                            "schedulable": true
+                          }
+                        ],
+                        "element_change_overhead": 0.0,
+                        "default": "out"
+                      },
+                      {
+                        "name": "Diffuser i'",
+                        "type": "diffuser_i_positions",
+                        "optical_elements": [
+                          {
+                            "name": "In Beam",
+                            "code": "in",
+                            "schedulable": true
+                          },
+                          {
+                            "name": "Out of Beam",
+                            "code": "out",
+                            "schedulable": true
+                          }
+                        ],
+                        "element_change_overhead": 0.0,
+                        "default": "out"
+                      },
+                      {
+                        "name": "Diffuser z'",
+                        "type": "diffuser_z_positions",
+                        "optical_elements": [
+                          {
+                            "name": "In Beam",
+                            "code": "in",
+                            "schedulable": true
+                          },
+                          {
+                            "name": "Out of Beam",
+                            "code": "out",
+                            "schedulable": true
+                          }
+                        ],
+                        "element_change_overhead": 0.0,
+                        "default": "out"
+                      }
+                    ]
                   },
                   "autoguider_camera": {
-                      "code": "mc03",
-                      "camera_type": {
-                          "id": 57,
-                          "size": "26.4x26.4",
-                          "pscale": 1.0,
-                          "default_mode": {
-                              "id": 43,
-                              "binning": 1,
-                              "overhead": 10,
-                              "readout": 10.0
-                          },
-                          "name": "2.0 meter Muscat",
-                          "code": "2M0-SCICAM-MUSCAT",
-                          "mode_set": [
-                              {
-                                  "binning": 1,
-                                  "overhead": 10,
-                                  "readout": 10.0
-                              }
-                          ],
-                          "fixed_overhead_per_exposure": 1.0,
-                          "front_padding": 90.0,
-                          "filter_change_time": 0.0,
-                          "config_change_time": 0.0,
-                          "acquire_exposure_time": 0.0,
-                          "acquire_processing_time": 0.0,
-                          "mode_types": [
-                              {
-                                  "type": "acquisition",
-                                  "modes": [
-                                      {
-                                          "name": "Acquire Off",
-                                          "overhead": 0.0,
-                                          "code": "OFF",
-                                          "params": {}
-                                      }
-                                  ],
-                                  "default": "OFF"
-                              },
-                              {
-                                  "type": "readout",
-                                  "modes": [
-                                      {
-                                          "name": "Muscat Slow Readout",
-                                          "overhead": 10.0,
-                                          "code": "MUSCAT_SLOW",
-                                          "params": {
-                                              "binning": 1
-                                          }
-                                      }
-                                  ],
-                                  "default": "MUSCAT_SLOW"
-                              },
-                              {
-                                  "type": "exposure",
-                                  "modes": [
-                                      {
-                                          "name": "Muscat Synchronous Exposure Mode",
-                                          "overhead": 0.0,
-                                          "code": "SYNCHRONOUS",
-                                          "params": {
-                                              "required_fields": [
-                                                  "exposure_time_g",
-                                                  "exposure_time_r",
-                                                  "exposure_time_i",
-                                                  "exposure_time_z",
-                                                  "exposure_mode"
-                                              ]
-                                          }
-                                      },
-                                      {
-                                          "name": "Muscat Asynchronous Exposure Mode",
-                                          "overhead": 0.0,
-                                          "code": "ASYNCHRONOUS",
-                                          "params": {
-                                              "required_fields": [
-                                                  "exposure_time_g",
-                                                  "exposure_time_r",
-                                                  "exposure_time_i",
-                                                  "exposure_time_z",
-                                                  "exposure_mode"
-                                              ]
-                                          }
-                                      }
-                                  ],
-                                  "default": "SYNCHRONOUS"
-                              },
-                              {
-                                  "type": "guiding",
-                                  "modes": [
-                                      {
-                                          "name": "On",
-                                          "overhead": 0.0,
-                                          "code": "ON",
-                                          "params": {}
-                                      }
-                                  ],
-                                  "default": "ON"
-                              }
-                          ],
-                          "default_acceptability_threshold": 90.0,
-                          "pixels_x": 2048,
-                          "pixels_y": 2048,
-                          "max_rois": 0,
-                          "allow_self_guiding": true,
-                          "configuration_types": [
-                              "EXPOSE",
-                              "REPEAT_EXPOSE",
-                              "BIAS",
-                              "DARK",
-                              "STANDARD",
-                              "SCRIPT",
-                              "AUTO_FOCUS",
-                              "SKY_FLAT",
-                              "ENGINEERING"
-                          ]
+                    "code": "mc03",
+                    "camera_type": {
+                      "id": 57,
+                      "size": "26.4x26.4",
+                      "pscale": 1.0,
+                      "default_mode": {
+                        "id": 43,
+                        "binning": 1,
+                        "overhead": 10,
+                        "readout": 10.0
                       },
-                      "optical_elements": {
-                          "diffuser_g_positions": "in,out",
-                          "diffuser_r_positions": "in,out",
-                          "diffuser_i_positions": "in,out",
-                          "diffuser_z_positions": "in,out"
-                      },
-                      "optical_element_groups": [
-                          {
-                              "name": "Diffuser g'",
-                              "type": "diffuser_g_positions",
-                              "optical_elements": [
-                                  {
-                                      "name": "In Beam",
-                                      "code": "in",
-                                      "schedulable": true
-                                  },
-                                  {
-                                      "name": "Out of Beam",
-                                      "code": "out",
-                                      "schedulable": true
-                                  }
-                              ],
-                              "element_change_overhead": 0.0,
-                              "default": "out"
-                          },
-                          {
-                              "name": "Diffuser r'",
-                              "type": "diffuser_r_positions",
-                              "optical_elements": [
-                                  {
-                                      "name": "In Beam",
-                                      "code": "in",
-                                      "schedulable": true
-                                  },
-                                  {
-                                      "name": "Out of Beam",
-                                      "code": "out",
-                                      "schedulable": true
-                                  }
-                              ],
-                              "element_change_overhead": 0.0,
-                              "default": "out"
-                          },
-                          {
-                              "name": "Diffuser i'",
-                              "type": "diffuser_i_positions",
-                              "optical_elements": [
-                                  {
-                                      "name": "In Beam",
-                                      "code": "in",
-                                      "schedulable": true
-                                  },
-                                  {
-                                      "name": "Out of Beam",
-                                      "code": "out",
-                                      "schedulable": true
-                                  }
-                              ],
-                              "element_change_overhead": 0.0,
-                              "default": "out"
-                          },
-                          {
-                              "name": "Diffuser z'",
-                              "type": "diffuser_z_positions",
-                              "optical_elements": [
-                                  {
-                                      "name": "In Beam",
-                                      "code": "in",
-                                      "schedulable": true
-                                  },
-                                  {
-                                      "name": "Out of Beam",
-                                      "code": "out",
-                                      "schedulable": true
-                                  }
-                              ],
-                              "element_change_overhead": 0.0,
-                              "default": "out"
-                          }
+                      "name": "2.0 meter Muscat",
+                      "code": "2M0-SCICAM-MUSCAT",
+                      "mode_set": [
+                        {
+                          "binning": 1,
+                          "overhead": 10,
+                          "readout": 10.0
+                        }
+                      ],
+                      "fixed_overhead_per_exposure": 1.0,
+                      "front_padding": 90.0,
+                      "filter_change_time": 0.0,
+                      "config_change_time": 0.0,
+                      "acquire_exposure_time": 0.0,
+                      "acquire_processing_time": 0.0,
+                      "mode_types": [
+                        {
+                          "type": "acquisition",
+                          "modes": [
+                            {
+                              "name": "Acquire Off",
+                              "overhead": 0.0,
+                              "code": "OFF",
+                              "params": {}
+                            }
+                          ],
+                          "default": "OFF"
+                        },
+                        {
+                          "type": "readout",
+                          "modes": [
+                            {
+                              "name": "Muscat Slow Readout",
+                              "overhead": 10.0,
+                              "code": "MUSCAT_SLOW",
+                              "params": {
+                                "binning": 1
+                              }
+                            }
+                          ],
+                          "default": "MUSCAT_SLOW"
+                        },
+                        {
+                          "type": "exposure",
+                          "modes": [
+                            {
+                              "name": "Muscat Synchronous Exposure Mode",
+                              "overhead": 0.0,
+                              "code": "SYNCHRONOUS",
+                              "params": {
+                                "required_fields": [
+                                  "exposure_time_g",
+                                  "exposure_time_r",
+                                  "exposure_time_i",
+                                  "exposure_time_z",
+                                  "exposure_mode"
+                                ]
+                              }
+                            },
+                            {
+                              "name": "Muscat Asynchronous Exposure Mode",
+                              "overhead": 0.0,
+                              "code": "ASYNCHRONOUS",
+                              "params": {
+                                "required_fields": [
+                                  "exposure_time_g",
+                                  "exposure_time_r",
+                                  "exposure_time_i",
+                                  "exposure_time_z",
+                                  "exposure_mode"
+                                ]
+                              }
+                            }
+                          ],
+                          "default": "SYNCHRONOUS"
+                        },
+                        {
+                          "type": "guiding",
+                          "modes": [
+                            {
+                              "name": "On",
+                              "overhead": 0.0,
+                              "code": "ON",
+                              "params": {}
+                            }
+                          ],
+                          "default": "ON"
+                        }
+                      ],
+                      "default_acceptability_threshold": 90.0,
+                      "pixels_x": 2048,
+                      "pixels_y": 2048,
+                      "max_rois": 0,
+                      "allow_self_guiding": true,
+                      "configuration_types": [
+                        "EXPOSE",
+                        "REPEAT_EXPOSE",
+                        "BIAS",
+                        "DARK",
+                        "STANDARD",
+                        "SCRIPT",
+                        "AUTO_FOCUS",
+                        "SKY_FLAT",
+                        "ENGINEERING"
                       ]
+                    },
+                    "optical_elements": {
+                      "diffuser_g_positions": "in,out",
+                      "diffuser_r_positions": "in,out",
+                      "diffuser_i_positions": "in,out",
+                      "diffuser_z_positions": "in,out"
+                    },
+                    "optical_element_groups": [
+                      {
+                        "name": "Diffuser g'",
+                        "type": "diffuser_g_positions",
+                        "optical_elements": [
+                          {
+                            "name": "In Beam",
+                            "code": "in",
+                            "schedulable": true
+                          },
+                          {
+                            "name": "Out of Beam",
+                            "code": "out",
+                            "schedulable": true
+                          }
+                        ],
+                        "element_change_overhead": 0.0,
+                        "default": "out"
+                      },
+                      {
+                        "name": "Diffuser r'",
+                        "type": "diffuser_r_positions",
+                        "optical_elements": [
+                          {
+                            "name": "In Beam",
+                            "code": "in",
+                            "schedulable": true
+                          },
+                          {
+                            "name": "Out of Beam",
+                            "code": "out",
+                            "schedulable": true
+                          }
+                        ],
+                        "element_change_overhead": 0.0,
+                        "default": "out"
+                      },
+                      {
+                        "name": "Diffuser i'",
+                        "type": "diffuser_i_positions",
+                        "optical_elements": [
+                          {
+                            "name": "In Beam",
+                            "code": "in",
+                            "schedulable": true
+                          },
+                          {
+                            "name": "Out of Beam",
+                            "code": "out",
+                            "schedulable": true
+                          }
+                        ],
+                        "element_change_overhead": 0.0,
+                        "default": "out"
+                      },
+                      {
+                        "name": "Diffuser z'",
+                        "type": "diffuser_z_positions",
+                        "optical_elements": [
+                          {
+                            "name": "In Beam",
+                            "code": "in",
+                            "schedulable": true
+                          },
+                          {
+                            "name": "Out of Beam",
+                            "code": "out",
+                            "schedulable": true
+                          }
+                        ],
+                        "element_change_overhead": 0.0,
+                        "default": "out"
+                      }
+                    ]
                   },
                   "__str__": "tst.domb.2m0a.mc03-mc03"
-              }
+                }
               ]
             }
           ]

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -168,7 +168,7 @@ class InstrumentConfigSerializer(serializers.ModelSerializer):
             ))
 
         extra_param_max_exp_time = 0
-        for field, value in data.get('extra_params').items():
+        for field, value in data.get('extra_params', {}).items():
             try:
                 if 'exposure_time' in field and float(value) > extra_param_max_exp_time:
                     extra_param_max_exp_time = float(value)

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -328,7 +328,7 @@ class ConfigurationSerializer(serializers.ModelSerializer):
                 else:
                     acquisition_config['mode'] = AcquisitionConfig.OFF
 
-            acquire_mode_error_msg = acquire_validation_helper.get_mode_error_msg(acquisition_config['mode'], 
+            acquire_mode_error_msg = acquire_validation_helper.get_mode_error_msg(acquisition_config['mode'],
                                                                                   acquisition_config)
             if acquire_mode_error_msg:
                 raise serializers.ValidationError(_(acquire_mode_error_msg))
@@ -360,7 +360,7 @@ class ConfigurationSerializer(serializers.ModelSerializer):
                         raise serializers.ValidationError(_(str(cdbe)))
             else:
                 # A readout mode is set - validate the mode
-                readout_error_msg = readout_validation_helper.get_mode_error_msg(instrument_config['mode'], 
+                readout_error_msg = readout_validation_helper.get_mode_error_msg(instrument_config['mode'],
                                                                                  instrument_config)
                 if readout_error_msg:
                     raise serializers.ValidationError(_(readout_error_msg))

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -54,7 +54,7 @@ class ModeValidationHelper:
             possible_modes.extend(self._modes[self._mode_type]['modes'])
         return possible_modes
 
-    def _unavailable_msg(self, mode_value: str, config: dict) -> str:
+    def _unavailable_msg(self, mode_value: str) -> str:
         if self._mode_type in self._modes:
             if not mode_value.lower() in [m['code'].lower() for m in self._modes[self._mode_type]['modes']]:
                 return (
@@ -457,7 +457,7 @@ class ConfigurationSerializer(serializers.ModelSerializer):
                 if exposure_mode_validation_helper.mode_is_not_set(instrument_config['extra_params']):
                     exposure_mode_to_set = exposure_mode_validation_helper.get_mode_to_set()
                     if exposure_mode_to_set['error']:
-                        raise serializers.ValidationError(_(rotator_mode_to_set['error']))
+                        raise serializers.ValidationError(_(exposure_mode_to_set['error']))
                     if exposure_mode_to_set['mode']:
                         instrument_config['extra_params']['exposure_mode'] = exposure_mode_to_set['mode']['code']
 

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -166,6 +166,23 @@ class InstrumentConfigSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(_(
                 'Currently only square binnings are supported. Please submit with bin_x == bin_y'
             ))
+
+        extra_param_max_exp_time = 0
+        for field, value in data.get('extra_params').items():
+            if 'exposure_time' in field and float(value) > extra_param_max_exp_time:
+                extra_param_max_exp_time = float(value)
+        if extra_param_max_exp_time > 0:
+            data['exposure_time'] = extra_param_max_exp_time
+
+        return data
+
+    def to_internal_value(self, data):
+        data = super().to_internal_value(data)
+        for field, value in data.get('extra_params', {}).items():
+            try:
+                data['extra_params'][field] = float(value)
+            except ValueError:
+                pass
         return data
 
     def to_representation(self, instance):

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -169,8 +169,11 @@ class InstrumentConfigSerializer(serializers.ModelSerializer):
 
         extra_param_max_exp_time = 0
         for field, value in data.get('extra_params').items():
-            if 'exposure_time' in field and float(value) > extra_param_max_exp_time:
-                extra_param_max_exp_time = float(value)
+            try:
+                if 'exposure_time' in field and float(value) > extra_param_max_exp_time:
+                    extra_param_max_exp_time = float(value)
+            except ValueError:
+                pass
         if extra_param_max_exp_time > 0:
             data['exposure_time'] = extra_param_max_exp_time
 

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -19,6 +19,7 @@ from observation_portal.requestgroups.models import (
 from observation_portal.requestgroups.models import DraftRequestGroup
 from observation_portal.common.state_changes import debit_ipp_time, TimeAllocationError, validate_ipp
 from observation_portal.requestgroups.target_helpers import TARGET_TYPE_HELPER_MAP
+from observation_portal.common.mixins import ExtraParamsFormatter
 from observation_portal.common.configdb import configdb, ConfigDB, ConfigDBException
 from observation_portal.requestgroups.duration_utils import (
     get_request_duration, get_request_duration_sum, get_total_duration_dict, OVERHEAD_ALLOWANCE,
@@ -150,7 +151,7 @@ class RegionOfInterestSerializer(serializers.ModelSerializer):
         return data
 
 
-class InstrumentConfigSerializer(serializers.ModelSerializer):
+class InstrumentConfigSerializer(ExtraParamsFormatter, serializers.ModelSerializer):
     exposure_time = serializers.FloatField(required=False, allow_null=True)
     rois = RegionOfInterestSerializer(many=True, required=False)
 
@@ -181,15 +182,6 @@ class InstrumentConfigSerializer(serializers.ModelSerializer):
 
         return data
 
-    def to_internal_value(self, data):
-        data = super().to_internal_value(data)
-        for field, value in data.get('extra_params', {}).items():
-            try:
-                data['extra_params'][field] = float(value)
-            except ValueError:
-                pass
-        return data
-
     def to_representation(self, instance):
         data = super().to_representation(instance)
         if not data['rois']:
@@ -206,7 +198,7 @@ class AcquisitionConfigSerializer(serializers.ModelSerializer):
         return data
 
 
-class GuidingConfigSerializer(serializers.ModelSerializer):
+class GuidingConfigSerializer(ExtraParamsFormatter, serializers.ModelSerializer):
     class Meta:
         model = GuidingConfig
         exclude = GuidingConfig.SERIALIZER_EXCLUDE
@@ -215,7 +207,7 @@ class GuidingConfigSerializer(serializers.ModelSerializer):
         return data
 
 
-class TargetSerializer(serializers.ModelSerializer):
+class TargetSerializer(ExtraParamsFormatter, serializers.ModelSerializer):
     class Meta:
         model = Target
         exclude = Target.SERIALIZER_EXCLUDE
@@ -240,7 +232,7 @@ class TargetSerializer(serializers.ModelSerializer):
         return data
 
 
-class ConfigurationSerializer(serializers.ModelSerializer):
+class ConfigurationSerializer(ExtraParamsFormatter, serializers.ModelSerializer):
     fill_window = serializers.BooleanField(required=False, write_only=True)
     constraints = ConstraintsSerializer()
     instrument_configs = InstrumentConfigSerializer(many=True)

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -1294,6 +1294,14 @@ class TestConfigurationApi(SetTimeMixin, APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('must have at least one instrument configuration', str(response.content))
 
+    def test_extra_params_saved_as_float_not_string(self):
+        good_data = self.generic_payload.copy()
+        good_data['requests'][0]['configurations'][0]['extra_params'] = {'test_value': '1.15'}
+        response = self.client.post(reverse('api:request_groups-list'), data=good_data)
+        self.assertEqual(response.status_code, 201)
+        extra_params = response.json()['requests'][0]['configurations'][0]['extra_params']
+        self.assertEqual(extra_params['test_value'], 1.15)
+
     def test_must_have_exposure_time(self):
         bad_data = self.generic_payload.copy()
         del bad_data['requests'][0]['configurations'][0]['instrument_configs'][0]['exposure_time']

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -1881,6 +1881,82 @@ class TestConfigurationApi(SetTimeMixin, APITestCase):
         self.assertIn('Currently only a single constraints', str(response.content))
 
 
+class TestMuscatValidationApi(SetTimeMixin, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.proposal = mixer.blend(Proposal)
+        self.user = blend_user()
+        self.client.force_login(self.user)
+
+        semester = mixer.blend(
+            Semester, id='2016B', start=datetime(2016, 9, 1, tzinfo=timezone.utc),
+            end=datetime(2016, 12, 31, tzinfo=timezone.utc)
+        )
+        self.time_allocation_1m0_sbig = mixer.blend(
+            TimeAllocation, proposal=self.proposal, semester=semester, instrument_type='2M0-SCICAM-MUSCAT',
+            std_allocation=100.0, std_time_used=0.0, rr_allocation=10, rr_time_used=0.0, ipp_limit=10.0,
+            ipp_time_available=5.0
+        )
+        mixer.blend(Membership, user=self.user, proposal=self.proposal)
+        self.generic_payload = copy.deepcopy(generic_payload)
+        self.generic_payload['proposal'] = self.proposal.id
+        self.generic_payload['requests'][0]['configurations'][0]['instrument_type'] = '2M0-SCICAM-MUSCAT'
+        self.generic_payload['requests'][0]['location']['telescope_class'] = '2m0'
+        del self.generic_payload['requests'][0]['configurations'][0]['instrument_configs'][0]['optical_elements']['filter']
+        self.generic_payload['requests'][0]['configurations'][0]['instrument_configs'][0]['extra_params'] = {
+            'exposure_time_g': 33.0,
+            'exposure_time_r': 29.0,
+            'exposure_time_i': 27.5,
+            'exposure_time_z': 25.8,
+            'exposure_mode': 'SYNCHRONOUS'
+        }
+        self.generic_payload['requests'][0]['configurations'][0]['instrument_configs'][0]['optical_elements'] = {
+            'diffuser_g_position': "in",
+            'diffuser_r_position': "out",
+            'diffuser_i_position': "out",
+            'diffuser_z_position': "out",
+        }
+
+    def test_accepts_good_muscat_request(self):
+        good_data = self.generic_payload.copy()
+        max_exposure_time = good_data['requests'][0]['configurations'][0]['instrument_configs'][0]['extra_params']['exposure_time_g']
+        response = self.client.post(reverse('api:request_groups-list'), data=good_data)
+        self.assertEqual(response.status_code, 201)
+        inst_config = response.json()['requests'][0]['configurations'][0]['instrument_configs'][0]
+        # check that the exposure_time field was set to the max of the extra params exposure times
+        self.assertEqual(inst_config['exposure_time'], max_exposure_time)
+
+    def test_sets_default_muscat_exposure_mode(self):
+        good_data = self.generic_payload.copy()
+        del good_data['requests'][0]['configurations'][0]['instrument_configs'][0]['extra_params']['exposure_mode']
+        response = self.client.post(reverse('api:request_groups-list'), data=good_data)
+        self.assertEqual(response.status_code, 201)
+        inst_config = response.json()['requests'][0]['configurations'][0]['instrument_configs'][0]
+        # check that the exposure_mode field is set to the default of SYNCHRONOUS
+        self.assertEqual(inst_config['extra_params']['exposure_mode'], 'SYNCHRONOUS')
+
+    def test_muscat_requires_extra_params_exposure_times_set(self):
+        bad_data = self.generic_payload.copy()
+        del bad_data['requests'][0]['configurations'][0]['instrument_configs'][0]['extra_params']['exposure_time_g']
+        response = self.client.post(reverse('api:request_groups-list'), data=bad_data)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('exposure_time_g', str(response.content))
+
+    def test_muscat_extra_param_exposure_time_must_be_number(self):
+        bad_data = self.generic_payload.copy()
+        bad_data['requests'][0]['configurations'][0]['instrument_configs'][0]['extra_params']['exposure_time_g'] = 'NotANumber'
+        response = self.client.post(reverse('api:request_groups-list'), data=bad_data)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('exposure_time_g must be a positive number', str(response.content))
+
+    def test_muscat_extra_param_exposure_time_must_be_positive(self):
+        bad_data = self.generic_payload.copy()
+        bad_data['requests'][0]['configurations'][0]['instrument_configs'][0]['extra_params']['exposure_time_g'] = -33.2
+        response = self.client.post(reverse('api:request_groups-list'), data=bad_data)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('exposure_time_g must be a positive number', str(response.content))
+
+
 class TestGetRequestApi(APITestCase):
     def setUp(self):
         super().setUp()

--- a/static/js/components/configuration.vue
+++ b/static/js/components/configuration.vue
@@ -53,7 +53,7 @@
         <b-col :md="show ? 6 : 12">
           <b-form>
             <customselect 
-              v-if="!simple_interface && datatype !='SPECTRA'"
+              v-if="!simple_interface && datatype !='SPECTRA' && guideModeOptions.length > 1"
               v-model="selectedImagerGuidingOption" 
               label="Guiding" 
               field="mode" 
@@ -277,6 +277,7 @@
             }
             if (this.available_instruments[this.selectedinstrument].modes.guiding.modes[gm].code == 'ON'){
               guideModes.push({text: 'Optional', value: 'OPTIONAL'})
+              this.selectedImagerGuidingOption = 'OPTIONAL';
             }
           }
           return guideModes;

--- a/static/js/components/configuration.vue
+++ b/static/js/components/configuration.vue
@@ -277,7 +277,6 @@
             }
             if (this.available_instruments[this.selectedinstrument].modes.guiding.modes[gm].code == 'ON'){
               guideModes.push({text: 'Optional', value: 'OPTIONAL'})
-              this.selectedImagerGuidingOption = 'OPTIONAL';
             }
           }
           return guideModes;
@@ -444,6 +443,10 @@
       },
       selectedinstrument: function(value) {
         if (this.configuration.instrument_type !== value) {
+          // Set the guide mode to OPTIONAL for muscat
+          if (value == '2M0-SCICAM-MUSCAT') {
+            this.selectedImagerGuidingOption = 'OPTIONAL';
+          }
           if (this.datatype === 'SPECTRA') {
             // Need to set up spectrograph here because the instrument might have changed
             // from NRES to FLOYDS, which have different aquire modes and configuration types

--- a/static/js/components/configuration.vue
+++ b/static/js/components/configuration.vue
@@ -61,7 +61,7 @@
                     attempted but observations are carried out even if guiding fails. If set to On, 
                     observations are aborted if guiding fails."
               :errors="{}" 
-              :options="imagerGuidingOptions"
+              :options="guideModeOptions"
               @input="update" 
             />
             <div 
@@ -241,7 +241,6 @@
             {value: 'REPEAT_EXPOSE', text: 'Exposure Sequence'}
           ]
         }
-        return [];
       },
       acquireModeOptions: function() {
         let options = [];
@@ -265,6 +264,25 @@
           }
         }
         return options;
+      },
+      guideModeOptions: function() {
+        if (this.selectedinstrument in this.available_instruments) {
+          let guideModes = [];
+          for (let gm in this.available_instruments[this.selectedinstrument].modes.guiding.modes) {
+            if (this.selectedinstrument != '2M0-SCICAM-MUSCAT') {
+              guideModes.push({
+                  text: this.available_instruments[this.selectedinstrument].modes.guiding.modes[gm].name,
+                  value: this.available_instruments[this.selectedinstrument].modes.guiding.modes[gm].code,
+              });
+            }
+            if (this.available_instruments[this.selectedinstrument].modes.guiding.modes[gm].code == 'ON'){
+              guideModes.push({text: 'Optional', value: 'OPTIONAL'})
+            }
+          }
+          return guideModes;
+        } else {
+          return [];
+        }
       },
       requiredAcquireModeFields: function() {
         for (let i in this.acquireModeOptions) {

--- a/static/js/components/instrumentconfig.vue
+++ b/static/js/components/instrumentconfig.vue
@@ -41,7 +41,8 @@
               :errors="errors.exposure_count" 
               @input="update"
             />
-            <customfield 
+            <customfield
+              v-if="selectedinstrument != '2M0-SCICAM-MUSCAT'"
               v-model="instrumentconfig.exposure_time" 
               label="Exposure Time" 
               field="exposure_time" 
@@ -64,6 +65,56 @@
               Suggested exposure time for an Arc is <strong>{{ suggestedArcExposureTime }} seconds</strong>
             </div>        
             </customfield>
+
+            <!-- MUSCAT instrument specific fields -->
+            <customselect
+              v-if="selectedinstrument == '2M0-SCICAM-MUSCAT'"
+              v-model="exposure_mode"
+              label="Exposure Mode"
+              field="exposure_mode"
+              :options="exposureModeOptions"
+              :errors="null"
+              desc="Exposure Mode. SYNCHRONOUS syncs the start time of exposures on all 4 cameras.
+                    ASYNCHRONOUS takes exposures as quickly as possible on each camera"
+              @input="update"
+            />
+            <customfield
+              v-if="selectedinstrument == '2M0-SCICAM-MUSCAT'"
+              v-model="exposure_time_g"
+              label="Exposure Time g'"
+              field="exposure_time_g"
+              :errors="null"
+              desc="Exposure Time for the g-band camera in Seconds"
+              @input="update"
+            />
+            <customfield
+              v-if="selectedinstrument == '2M0-SCICAM-MUSCAT'"
+              v-model="exposure_time_r"
+              label="Exposure Time r'"
+              field="exposure_time_r"
+              :errors="null"
+              desc="Exposure Time for the r-band camera in Seconds"
+              @input="update"
+            />
+            <customfield
+              v-if="selectedinstrument == '2M0-SCICAM-MUSCAT'"
+              v-model="exposure_time_i"
+              label="Exposure Time i'"
+              field="exposure_time_i"
+              :errors="null"
+              desc="Exposure Time for the i-band camera in Seconds"
+              @input="update"
+            />
+            <customfield
+              v-if="selectedinstrument == '2M0-SCICAM-MUSCAT'"
+              v-model="exposure_time_z"
+              label="Exposure Time z'"
+              field="exposure_time_z"
+              :errors="null"
+              desc="Exposure Time for the z-band camera in Seconds"
+              @input="update"
+            />
+
             <customselect
               v-if="readoutModeOptions.length > 1"
               v-model="instrumentconfig.mode"
@@ -167,14 +218,38 @@ export default {
   data: function() {
     return {
       defocus: 0,
-      opticalElementUpdates: 0
+      exposure_time_g = 0,
+      exposure_time_r = 0,
+      exposure_time_i = 0,
+      exposure_time_z = 0,
+      exposure_mode = 0,
+      opticalElementUpdates: 0,
+      exposureModeOptions: [
+          {value: 'SYNCHRONOUS', text: 'Synchronous'},
+          {value: 'ASYNCHRONOUS', text: 'Asynchronous'}
+      ]
     }
   },
   mounted: function() {
-    // If a draft is loaded in that has a defocus set in the extra_params, update the defocus
+    // If a draft is loaded in that has any extra_params set, update the corresponding params
     // here since extra_params is not reactive and cannot be watched 
     if (this.instrumentconfig.extra_params.defocus) {
       this.defocus = this.instrumentconfig.extra_params.defocus;
+    }
+    if (this.instrumentconfig.extra_params.exposure_time_g) {
+      this.exposure_time_g = this.instrumentconfig.extra_params.exposure_time_g;
+    }
+    if (this.instrumentconfig.extra_params.exposure_time_r) {
+      this.exposure_time_g = this.instrumentconfig.extra_params.exposure_time_r;
+    }
+    if (this.instrumentconfig.extra_params.exposure_time_i) {
+      this.exposure_time_g = this.instrumentconfig.extra_params.exposure_time_i;
+    }
+    if (this.instrumentconfig.extra_params.exposure_time_z) {
+      this.exposure_time_g = this.instrumentconfig.extra_params.exposure_time_z;
+    }
+    if (this.instrumentconfig.extra_params.exposure_mode) {
+      this.exposure_time_g = this.instrumentconfig.extra_params.exposure_mode;
     }
   },
   computed: {
@@ -365,6 +440,42 @@ export default {
     defocus: function(value) {
       this.instrumentconfig.extra_params.defocus = value || undefined;
       this.update();
+    },
+    exposure_time_g: function(value) {
+      this.instrumentconfig.extra_params.exposure_time_g = value || undefined;
+      this.update();
+    },
+    exposure_time_r: function(value) {
+      this.instrumentconfig.extra_params.exposure_time_r = value || undefined;
+      this.update();
+    },
+    exposure_time_i: function(value) {
+      this.instrumentconfig.extra_params.exposure_time_i = value || undefined;
+      this.update();
+    },
+    exposure_time_z: function(value) {
+      this.instrumentconfig.extra_params.exposure_time_z = value || undefined;
+      this.update();
+    },
+    exposure_mode: function(value) {
+      this.instrumentconfig.extra_params.exposure_mode = value || undefined;
+      this.update();
+    },
+    selectedinstrument: function(value) {
+      if (value === '2M0-SCICAM-MUSCT') {
+        this.instrumentconfig.extra_params.exposure_time_g = this.instrumentconfig.exposure_time;
+        this.instrumentconfig.extra_params.exposure_time_r = this.instrumentconfig.exposure_time;
+        this.instrumentconfig.extra_params.exposure_time_i = this.instrumentconfig.exposure_time;
+        this.instrumentconfig.extra_params.exposure_time_z = this.instrumentconfig.exposure_time;
+        this.instrumentconfig.extra_params.exposure_mode = "SYNCHRONOUS";
+      }
+      else {
+        this.instrumentconfig.extra_params.exposure_time_g = undefined;
+        this.instrumentconfig.extra_params.exposure_time_r = undefined;
+        this.instrumentconfig.extra_params.exposure_time_i = undefined;
+        this.instrumentconfig.extra_params.exposure_time_z = undefined;
+        this.instrumentconfig.extra_params.exposure_mode = undefined;
+      }
     },
     datatype: function(value) {
       if (value === 'IMAGE') {

--- a/static/js/components/instrumentconfig.vue
+++ b/static/js/components/instrumentconfig.vue
@@ -378,6 +378,16 @@ export default {
       }
       this.update();
     },
+    updateExposureTime: function() {
+      this.instrumentconfig.exposure_time = Math.max(
+        this.instrumentconfig.extra_params.exposure_time_g,
+        this.instrumentconfig.extra_params.exposure_time_r,
+        this.instrumentconfig.extra_params.exposure_time_i,
+        this.instrumentconfig.extra_params.exposure_time_z
+      );
+
+      this.update();
+    },
     updateOpticalElement: function() {
       // The optical element fields are not reactive as they change/ are deleted/ don't exist on start.
       // Increment this reactive variable to watch for changed to the optical elements
@@ -448,19 +458,19 @@ export default {
     },
     exposure_time_g: function(value) {
       this.instrumentconfig.extra_params.exposure_time_g = value || undefined;
-      this.update();
+      this.updateExposureTime();
     },
     exposure_time_r: function(value) {
       this.instrumentconfig.extra_params.exposure_time_r = value || undefined;
-      this.update();
+      this.updateExposureTime();
     },
     exposure_time_i: function(value) {
       this.instrumentconfig.extra_params.exposure_time_i = value || undefined;
-      this.update();
+      this.updateExposureTime();
     },
     exposure_time_z: function(value) {
       this.instrumentconfig.extra_params.exposure_time_z = value || undefined;
-      this.update();
+      this.updateExposureTime();
     },
     exposure_mode: function(value) {
       this.instrumentconfig.extra_params.exposure_mode = value || undefined;

--- a/static/js/components/instrumentconfig.vue
+++ b/static/js/components/instrumentconfig.vue
@@ -81,7 +81,7 @@
             <customfield
               v-if="selectedinstrument == '2M0-SCICAM-MUSCAT'"
               v-model="exposure_time_g"
-              label="Exposure Time g'"
+              label="Exposure Time g"
               field="exposure_time_g"
               :errors="null"
               desc="Exposure Time for the g-band camera in Seconds"
@@ -90,7 +90,7 @@
             <customfield
               v-if="selectedinstrument == '2M0-SCICAM-MUSCAT'"
               v-model="exposure_time_r"
-              label="Exposure Time r'"
+              label="Exposure Time r"
               field="exposure_time_r"
               :errors="null"
               desc="Exposure Time for the r-band camera in Seconds"
@@ -99,7 +99,7 @@
             <customfield
               v-if="selectedinstrument == '2M0-SCICAM-MUSCAT'"
               v-model="exposure_time_i"
-              label="Exposure Time i'"
+              label="Exposure Time i"
               field="exposure_time_i"
               :errors="null"
               desc="Exposure Time for the i-band camera in Seconds"
@@ -108,7 +108,7 @@
             <customfield
               v-if="selectedinstrument == '2M0-SCICAM-MUSCAT'"
               v-model="exposure_time_z"
-              label="Exposure Time z'"
+              label="Exposure Time z"
               field="exposure_time_z"
               :errors="null"
               desc="Exposure Time for the z-band camera in Seconds"
@@ -218,15 +218,15 @@ export default {
   data: function() {
     return {
       defocus: 0,
-      exposure_time_g = 0,
-      exposure_time_r = 0,
-      exposure_time_i = 0,
-      exposure_time_z = 0,
-      exposure_mode = 0,
+      exposure_time_g: 0,
+      exposure_time_r: 0,
+      exposure_time_i: 0,
+      exposure_time_z: 0,
+      exposure_mode: "SYNCHRONOUS",
       opticalElementUpdates: 0,
       exposureModeOptions: [
-          {value: 'SYNCHRONOUS', text: 'Synchronous'},
-          {value: 'ASYNCHRONOUS', text: 'Asynchronous'}
+          {value: "SYNCHRONOUS", text: "Synchronous"},
+          {value: "ASYNCHRONOUS", text: "Asynchronous"}
       ]
     }
   },
@@ -240,16 +240,16 @@ export default {
       this.exposure_time_g = this.instrumentconfig.extra_params.exposure_time_g;
     }
     if (this.instrumentconfig.extra_params.exposure_time_r) {
-      this.exposure_time_g = this.instrumentconfig.extra_params.exposure_time_r;
+      this.exposure_time_r = this.instrumentconfig.extra_params.exposure_time_r;
     }
     if (this.instrumentconfig.extra_params.exposure_time_i) {
-      this.exposure_time_g = this.instrumentconfig.extra_params.exposure_time_i;
+      this.exposure_time_i = this.instrumentconfig.extra_params.exposure_time_i;
     }
     if (this.instrumentconfig.extra_params.exposure_time_z) {
-      this.exposure_time_g = this.instrumentconfig.extra_params.exposure_time_z;
+      this.exposure_time_z = this.instrumentconfig.extra_params.exposure_time_z;
     }
     if (this.instrumentconfig.extra_params.exposure_mode) {
-      this.exposure_time_g = this.instrumentconfig.extra_params.exposure_mode;
+      this.exposure_mode = this.instrumentconfig.extra_params.exposure_mode;
     }
   },
   computed: {
@@ -298,13 +298,14 @@ export default {
           let oe_type = oe_group_type.substring(0, oe_group_type.length - 1);
           oe_groups[oe_type] = {};
           oe_groups[oe_type]['type'] = oe_type;
-          oe_groups[oe_type]['label'] = _.capitalize(oe_type);
+          oe_groups[oe_type]['label'] = _.capitalize(oe_type).split("_").join(" ");
           let elements = [];
           for (let element in this.available_instruments[this.selectedinstrument].optical_elements[oe_group_type]) {
             if (this.available_instruments[this.selectedinstrument].optical_elements[oe_group_type][element].schedulable) {
               elements.push({
                 value: this.available_instruments[this.selectedinstrument].optical_elements[oe_group_type][element].code,
-                text: this.available_instruments[this.selectedinstrument].optical_elements[oe_group_type][element].name
+                text: this.available_instruments[this.selectedinstrument].optical_elements[oe_group_type][element].name,
+                default: this.available_instruments[this.selectedinstrument].optical_elements[oe_group_type][element].default
               });
             }
           }
@@ -430,8 +431,12 @@ export default {
         this.instrumentconfig.optical_elements.filter = 'b';
       } else {
         for (let oe_type in value) {
-          if (value[oe_type]['options'].length > 0) {
-            this.instrumentconfig.optical_elements[oe_type] = value[oe_type]['options'][0].value;
+          for (let oe_value_idx in value[oe_type]['options'])
+          {
+            if (value[oe_type]['options'][oe_value_idx].default)
+            {
+              this.instrumentconfig.optical_elements[oe_type] = value[oe_type]['options'][oe_value_idx].value;
+            }
           }
         }
       }
@@ -462,12 +467,12 @@ export default {
       this.update();
     },
     selectedinstrument: function(value) {
-      if (value === '2M0-SCICAM-MUSCT') {
-        this.instrumentconfig.extra_params.exposure_time_g = this.instrumentconfig.exposure_time;
-        this.instrumentconfig.extra_params.exposure_time_r = this.instrumentconfig.exposure_time;
-        this.instrumentconfig.extra_params.exposure_time_i = this.instrumentconfig.exposure_time;
-        this.instrumentconfig.extra_params.exposure_time_z = this.instrumentconfig.exposure_time;
-        this.instrumentconfig.extra_params.exposure_mode = "SYNCHRONOUS";
+      if (value === '2M0-SCICAM-MUSCAT') {
+        this.instrumentconfig.extra_params.exposure_time_g = this.exposure_time_g = this.instrumentconfig.exposure_time;
+        this.instrumentconfig.extra_params.exposure_time_r = this.exposure_time_r = this.instrumentconfig.exposure_time;
+        this.instrumentconfig.extra_params.exposure_time_i = this.exposure_time_i = this.instrumentconfig.exposure_time;
+        this.instrumentconfig.extra_params.exposure_time_z = this.exposure_time_z = this.instrumentconfig.exposure_time;
+        this.instrumentconfig.extra_params.exposure_mode = this.exposure_mode = "SYNCHRONOUS";
       }
       else {
         this.instrumentconfig.extra_params.exposure_time_g = undefined;

--- a/static/js/request_detail.vue
+++ b/static/js/request_detail.vue
@@ -108,6 +108,7 @@
                                 <td><strong>Exposure Time</strong></td>
                                 <td><strong>Exposure Count</strong></td>
                                 <td><strong>Optical Elements</strong></td>
+                                <td><strong>Extra Params</strong></td>
                               </tr>
                             </thead>
                             <tbody>
@@ -120,6 +121,8 @@
                                 <td>{{ instrument_config.exposure_time | formatValue }}</td>
                                 <td>{{ instrument_config.exposure_count | formatValue }}</td>
                                 <td v-if="!isObjEmpty(instrument_config.optical_elements)">{{ instrument_config.optical_elements | formatValue }}</td>
+                                <td v-else>None</td>
+                                <td v-if="!isObjEmpty(instrument_config.extra_params)">{{ instrument_config.extra_params | formatValue }}</td>
                                 <td v-else>None</td>
                               </tr>
                             </tbody>


### PR DESCRIPTION
I leveraged the extra_params requirements we already had in place for GenericModes from configdb to do most of the validation for us. The only specific validation is with checking that the exposure_time_* fields are non-negative numbers (since it doesn't do any type checking by default). I think we could integrate in some basic type checking automatically with the required params in configdb as well, but not sure if its worth doing now, or wait for a bigger overhaul of configdb/obs portal to include it, since it should help a lot with generalizing stuff