### PR TITLE
Add query params to the instrument information endpoint

### DIFF
--- a/observation_portal/common/test_data/configdb.json
+++ b/observation_portal/common/test_data/configdb.json
@@ -1401,6 +1401,115 @@
                     ]
                   },
                   "__str__": "tst.domc.1m0a.xx11-xx11"
+                },
+                {
+                  "state": "MANUAL",
+                  "code": "xx12",
+                  "autoguider_camera": {
+                    "code": "ef12",
+                    "camera_type": {
+                      "code": "1M0-SCICAM-AG",
+                      "allow_self_guiding": true
+                    }
+                  },
+                  "science_camera": {
+                    "code": "xx12",
+                    "camera_type": {
+                      "code": "1M0-SCICAM-SBXX",
+                      "name": "1M0-SCICAM-SBXX",
+                      "allow_self_guiding": true,
+                      "configuration_types": [
+                        "EXPOSE",
+                        "REPEAT_EXPOSE",
+                        "BIAS",
+                        "DARK",
+                        "SCRIPT",
+                        "SKY_FLAT"
+                      ],
+                      "default_acceptability_threshold": 100,
+                      "pixels_x": 1000,
+                      "pixels_y": 1000,
+                      "max_rois": 0,
+                      "config_change_time": 0,
+                      "acquire_exposure_time": 0,
+                      "front_padding": 90,
+                      "fixed_overhead_per_exposure": 1,
+                      "mode_types": [
+                        {
+                          "type": "readout",
+                          "default": "1m0_sbig_2",
+                          "modes": [
+                            {
+                              "code": "1m0_sbig_1",
+                              "overhead": 35.0,
+                              "validation_schema": {
+                                "bin_x": {"type": "integer", "allowed": [1], "default": 1},
+                                "bin_y": {"type": "integer", "allowed": [1], "default": 1}
+                              }
+                            },
+                            {
+                              "code": "1m0_sbig_2",
+                              "overhead": 14.5,
+                              "validation_schema": {
+                                "bin_x": {"type": "integer", "allowed": [2], "default": 2},
+                                "bin_y": {"type": "integer", "allowed": [2], "default": 2}
+                              }
+                            },
+                            {
+                              "code": "1m0_sbig_3",
+                              "overhead": 11.5,
+                              "validation_schema": {
+                                "bin_x": {"type": "integer", "allowed": [3], "default": 3},
+                                "bin_y": {"type": "integer", "allowed": [3], "default": 3}
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "acquisition",
+                          "default": "OFF",
+                          "modes": [
+                            {
+                              "code": "OFF",
+                              "overhead": 0.0,
+                              "validation_schema": {}
+                            }
+                          ]
+                        },
+                        {
+                          "type": "guiding",
+                          "default": "OFF",
+                          "modes": [
+                            {
+                              "code": "OFF",
+                              "overhead": 0.0,
+                              "validation_schema": {}
+                            },
+                            {
+                              "code": "ON",
+                              "overhead": 0.0,
+                              "validation_schema": {}
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "optical_element_groups": [
+                      {
+                        "type": "filters",
+                        "element_change_overhead": 2,
+                        "optical_elements": [
+                          {
+                            "name": "Air",
+                            "code": "air",
+                            "schedulable": false
+                          }
+                        ],
+                        "default": "air"
+                      }
+                    ]
+                  },
+                  "__str__": "tst.domc.1m0a.xx12-xx12"
                 }
               ]
             }

--- a/observation_portal/requestgroups/test/test_views.py
+++ b/observation_portal/requestgroups/test/test_views.py
@@ -1,11 +1,9 @@
 from django.test import TestCase
-from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils import timezone
 from mixer.backend.django import mixer
 from unittest.mock import patch
 
-from observation_portal.accounts.models import Profile
 from observation_portal.accounts.test_utils import blend_user
 from observation_portal.proposals.models import Proposal, Membership
 from observation_portal.requestgroups.models import RequestGroup, Request, Configuration
@@ -230,6 +228,38 @@ class TestTelescopeStates(TelescopeStatesFromFile):
 
 
 class TestInstrumentInformation(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.staff_user = blend_user(user_params={'is_staff': True})
+
     def test_instrument_information(self):
         response = self.client.get(reverse('api:instruments_information'))
         self.assertIn('1M0-SCICAM-SBIG', response.json())
+
+    def test_instrument_information_for_specific_telescope(self):
+        response = self.client.get(reverse('api:instruments_information') + '?telescope=2m0a')
+        self.assertIn('2M0-FLOYDS-SCICAM', response.json())
+        self.assertNotIn('1M0-SCICAM-SBIG', response.json())
+
+    def test_instrument_information_for_nonexistent_location(self):
+        response = self.client.get(reverse('api:instruments_information') + '?site=idontexist')
+        self.assertEqual(len(response.json()), 0)
+
+    def test_instrument_information_for_specific_instrument_type(self):
+        response = self.client.get(reverse('api:instruments_information') + '?instrument_type=1M0-SCICAM-SBIG')
+        self.assertEqual(len(response.json()), 1)
+        self.assertIn('1M0-SCICAM-SBIG', response.json())
+
+    def test_non_staff_user_can_only_see_schedulable(self):
+        response = self.client.get(reverse('api:instruments_information') + '?only_schedulable=false')
+        self.assertNotIn('1M0-SCICAM-SBXX', response.json())
+
+    def test_staff_user_can_see_non_schedulable_by_default(self):
+        self.client.force_login(self.staff_user)
+        response = self.client.get(reverse('api:instruments_information'))
+        self.assertIn('1M0-SCICAM-SBXX', response.json())
+
+    def test_staff_user_can_request_only_schedulable(self):
+        self.client.force_login(self.staff_user)
+        response = self.client.get(reverse('api:instruments_information') + '?only_schedulable=true')
+        self.assertNotIn('1M0-SCICAM-SBXX', response.json())


### PR DESCRIPTION
Adds query params to the `/api/instruments/` endpoint to allow a user to filter down the instruments in the response.