### PR TITLE
Redirect to current semester view

### DIFF
--- a/observation_portal/proposals/test_views.py
+++ b/observation_portal/proposals/test_views.py
@@ -409,4 +409,4 @@ class TestSemesterDetail(TestCase):
 
     def test_current_redirect(self):
         response = self.client.get(reverse('proposals:semester-current'))
-        self.assertContains(response, self.semester.id)
+        self.assertEqual(response.status_code, 302)

--- a/observation_portal/proposals/test_views.py
+++ b/observation_portal/proposals/test_views.py
@@ -406,3 +406,7 @@ class TestSemesterDetail(TestCase):
     def test_view_summary(self):
         response = self.client.get(reverse('proposals:semester-detail', kwargs={'pk': self.semester.id}))
         self.assertContains(response, self.proposal.title)
+
+    def test_current_redirect(self):
+        response = self.client.get(reverse('proposals:semester-current'))
+        self.assertContains(response, self.semester.id)

--- a/observation_portal/proposals/urls.py
+++ b/observation_portal/proposals/urls.py
@@ -4,11 +4,13 @@ from django.views.decorators.http import require_POST
 from observation_portal.proposals.views import ProposalDetailView, ProposalListView, InviteCreateView
 from observation_portal.proposals.views import MembershipDeleteView, SemesterAdminView, MembershipLimitView
 from observation_portal.proposals.views import GlobalMembershipLimitView, SemesterDetailView, ProposalInviteDeleteView
+from observation_portal.proposals.views import CurrentSemesterRedirect
 
 app_name = 'proposals'
 urlpatterns = [
     url(r'^membership/(?P<pk>.+)/delete/$', MembershipDeleteView.as_view(), name='membership-delete'),
     url(r'^membership/(?P<pk>.+)/limit/$', MembershipLimitView.as_view(), name='membership-limit'),
+    url(r'^semester/current/$', CurrentSemesterRedirect.as_view(), name='semester-current'),
     url(r'^semester/(?P<pk>.+)/$', SemesterDetailView.as_view(), name='semester-detail'),
     url(r'^semesteradmin/(?P<pk>.+)/$', SemesterAdminView.as_view(), name='semester-admin'),
     url(r'^invitation/(?P<pk>.+)/delete/$', ProposalInviteDeleteView.as_view(), name='proposalinvite-delete'),

--- a/observation_portal/proposals/views.py
+++ b/observation_portal/proposals/views.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+
 from django.views import View
+from django.views.generic.base import RedirectView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import DeleteView
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -168,3 +171,15 @@ class SemesterAdminView(UserPassesTestMixin, DetailView):
         context = super().get_context_data(**kwargs)
         context['semesters'] = Semester.objects.all().order_by('-start')
         return context
+
+class CurrentSemesterRedirect(RedirectView):
+    permanent = False
+    pattern_name = 'proposals:semester-detail'
+
+    def get_redirect_url(self, *args, **kwargs):
+        now = datetime.utcnow()
+        semesters = Semester.objects.filter(start__lte=now, end__gte=now)
+        try:
+            return reverse(self.pattern_name, kwargs={'pk':semesters[0].id})
+        except IndexError:
+            return reverse('list')

--- a/observation_portal/proposals/views.py
+++ b/observation_portal/proposals/views.py
@@ -182,4 +182,4 @@ class CurrentSemesterRedirect(RedirectView):
         try:
             return reverse(self.pattern_name, kwargs={'pk':semesters[0].id})
         except IndexError:
-            return reverse('list')
+            return reverse('proposals:list')


### PR DESCRIPTION
It would be really useful to be able to link to the current semester with an unchanging link in the main LCO website. Because its manually updated it always ends being forgotten and at least 1 semester out of date