### PR TITLE
Fix proposal invite

### DIFF
--- a/observation_portal/proposals/test_views.py
+++ b/observation_portal/proposals/test_views.py
@@ -221,6 +221,16 @@ class TestProposalInvite(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, f'You cannot invite yourself ({self.pi_user.email}) to be a Co-Investigator')
 
+    def test_cannot_invite_user_that_is_already_member(self):
+        self.client.force_login(self.pi_user)
+        response = self.client.post(
+            reverse('proposals:invite', kwargs={'pk': self.proposal.id}),
+            data={'email': self.ci_user.email},
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'User with email {self.ci_user.email} is already a member of this proposal')
+
 
 class TestProposalList(TestCase):
     def setUp(self):

--- a/observation_portal/proposals/views.py
+++ b/observation_portal/proposals/views.py
@@ -119,6 +119,9 @@ class InviteCreateView(LoginRequiredMixin, View):
             if email.lower() == request.user.email.lower():
                 messages.error(request, f'You cannot invite yourself ({email}) to be a Co-Investigator')
                 valid = False
+            if Membership.objects.filter(proposal=proposal, user__email__iexact=email).exists():
+                messages.error(request, f'User with email {email} is already a member of this proposal')
+                valid = False
         if valid:
             proposal.add_users(emails, Membership.CI)
             messages.success(request, _('Co Investigator(s) invited'))


### PR DESCRIPTION
Check first if a user is already a member of a proposal before adding them as a member.