### PR TITLE
Add a filter to get a requestgroup by a request id

### DIFF
--- a/observation_portal/observations/filters.py
+++ b/observation_portal/observations/filters.py
@@ -45,8 +45,8 @@ class ObservationFilter(mixins.CustomIsoDateTimeFilterMixin, django_filters.Filt
         label='Modified After (Inclusive)',
         widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
     )
-    request_id = django_filters.CharFilter(field_name='request__id')
-    request_group_id = django_filters.CharFilter(field_name='request__request_group__id', label='Request Group ID')
+    request_id = django_filters.NumberFilter(field_name='request__id')
+    request_group_id = django_filters.NumberFilter(field_name='request__request_group__id', label='Request Group ID')
     state = django_filters.MultipleChoiceFilter(choices=Observation.STATE_CHOICES, field_name='state')
     observation_type = django_filters.MultipleChoiceFilter(
         choices=RequestGroup.OBSERVATION_TYPES,

--- a/observation_portal/requestgroups/filters.py
+++ b/observation_portal/requestgroups/filters.py
@@ -31,7 +31,7 @@ class RequestGroupFilter(django_filters.FilterSet):
             'modified': 'Last Update'
         }
     )
-    request_id = django_filters.CharFilter(field_name='requests__id')
+    request_id = django_filters.NumberFilter(field_name='requests__id')
 
     class Meta:
         model = RequestGroup

--- a/observation_portal/requestgroups/filters.py
+++ b/observation_portal/requestgroups/filters.py
@@ -31,12 +31,13 @@ class RequestGroupFilter(django_filters.FilterSet):
             'modified': 'Last Update'
         }
     )
+    request_id = django_filters.CharFilter(field_name='requests__id')
 
     class Meta:
         model = RequestGroup
         fields = (
             'id', 'submitter', 'proposal', 'name', 'observation_type', 'operator', 'ipp_value',  'exclude_state',
-            'state', 'created_after', 'created_before', 'user', 'modified_after', 'modified_before'
+            'state', 'created_after', 'created_before', 'user', 'modified_after', 'modified_before', 'request_id'
         )
 
 


### PR DESCRIPTION
The separated frontend needs to be able to get the requestgroup given a request ID for the request detail page.