### PR TITLE
Restrict muscat configurations to only one instrument config

### DIFF
--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -300,7 +300,9 @@ class ConfigurationSerializer(ExtraParamsFormatter, serializers.ModelSerializer)
             raise serializers.ValidationError(_(f'Multiple instrument configs are not allowed for type {data["type"]}'))
 
         if len(data['instrument_configs']) > 1 and instrument_type == '2M0-SCICAM-MUSCAT':
-            raise serializers.ValidationError(_('Multiple instrument configs are not allowed for muscat'))
+            raise serializers.ValidationError(_(
+                'Multiple instrument configs are not allowed for the instrument 2M0-SCICAM-MUSCAT'
+            ))
 
         # Validate the guide mode
         guide_validation_helper = ModeValidationHelper('guiding', instrument_type, modes['guiding'])

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -299,6 +299,9 @@ class ConfigurationSerializer(ExtraParamsFormatter, serializers.ModelSerializer)
         if len(data['instrument_configs']) > 1 and data['type'] in ['SCRIPT', 'SKY_FLAT']:
             raise serializers.ValidationError(_(f'Multiple instrument configs are not allowed for type {data["type"]}'))
 
+        if len(data['instrument_configs']) > 1 and instrument_type == '2M0-SCICAM-MUSCAT':
+            raise serializers.ValidationError(_('Multiple instrument configs are not allowed for muscat'))
+
         # Validate the guide mode
         guide_validation_helper = ModeValidationHelper('guiding', instrument_type, modes['guiding'])
 

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -1995,6 +1995,13 @@ class TestMuscatValidationApi(SetTimeMixin, APITestCase):
         self.assertIn('exposure_time_g error: min value is 0', str(response.content))
         self.assertIn('exposure_time_i error: min value is 0', str(response.content))
 
+    def test_do_not_allow_more_than_one_instrument_config(self):
+        bad_data = self.generic_payload.copy()
+        instrument_config = copy.deepcopy(bad_data['requests'][0]['configurations'][0]['instrument_configs'][0])
+        bad_data['requests'][0]['configurations'][0]['instrument_configs'].append(instrument_config)
+        response = self.client.post(reverse('api:request_groups-list'), data=bad_data)
+        self.assertContains(response, 'Multiple instrument configs are not allowed for muscat', status_code=400)
+
 
 class TestGetRequestApi(APITestCase):
     def setUp(self):

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -2000,7 +2000,8 @@ class TestMuscatValidationApi(SetTimeMixin, APITestCase):
         instrument_config = copy.deepcopy(bad_data['requests'][0]['configurations'][0]['instrument_configs'][0])
         bad_data['requests'][0]['configurations'][0]['instrument_configs'].append(instrument_config)
         response = self.client.post(reverse('api:request_groups-list'), data=bad_data)
-        self.assertContains(response, 'Multiple instrument configs are not allowed for muscat', status_code=400)
+        expected_message = 'Multiple instrument configs are not allowed for the instrument 2M0-SCICAM-MUSCAT'
+        self.assertContains(response, expected_message, status_code=400)
 
 
 class TestGetRequestApi(APITestCase):


### PR DESCRIPTION
It was decided that multiple instrument configs do not make sense for a muscat configuration, so restrict the number of instrument configs to one.