### PR TITLE
Fix/nonetype-in-extra-params

### DIFF
--- a/observation_portal/common/mixins.py
+++ b/observation_portal/common/mixins.py
@@ -41,15 +41,16 @@ class CustomIsoDateTimeFilterMixin(object):
                 f.field_class = CustomIsoDateTimeField
         return filters
 
+
 class ExtraParamsFormatter(object):
-    ''' This should be mixed in with Serializers that have extra_params JSON fields, to ensure the float values are
+    """ This should be mixed in with Serializers that have extra_params JSON fields, to ensure the float values are
         stored as float values in the db instead of as strings
-    '''
+    """
     def to_internal_value(self, data):
         data = super().to_internal_value(data)
         for field, value in data.get('extra_params', {}).items():
             try:
                 data['extra_params'][field] = float(value)
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
         return data

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -1303,6 +1303,20 @@ class TestConfigurationApi(SetTimeMixin, APITestCase):
         extra_params = response.json()['requests'][0]['configurations'][0]['extra_params']
         self.assertEqual(extra_params['test_value'], 1.15)
 
+    def test_extra_param_set_to_none_ok(self):
+        good_data = self.generic_payload.copy()
+        good_data['requests'][0]['configurations'][0]['extra_params'] = {'test_value': None}
+        response = self.client.post(reverse('api:request_groups-list'), data=good_data)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['requests'][0]['configurations'][0]['extra_params']['test_value'], None)
+
+    def test_extra_param_set_to_string_ok(self):
+        good_data = self.generic_payload.copy()
+        good_data['requests'][0]['configurations'][0]['extra_params'] = {'test_value': ''}
+        response = self.client.post(reverse('api:request_groups-list'), data=good_data)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['requests'][0]['configurations'][0]['extra_params']['test_value'], '')
+
     def test_must_have_exposure_time(self):
         bad_data = self.generic_payload.copy()
         del bad_data['requests'][0]['configurations'][0]['instrument_configs'][0]['exposure_time']


### PR DESCRIPTION
Handle `TypeError` in addition to the `ValueError` when casting the value of an extra param to a float in the `ExtraParamsFormatter` mixin. A TypeError is raised when the value is `None`.