### PR TITLE
Include proper motion for all example targets

### DIFF
--- a/observation_portal/requestgroups/management/commands/create_example_requests.py
+++ b/observation_portal/requestgroups/management/commands/create_example_requests.py
@@ -65,6 +65,8 @@ TARGET_LIST = [
         "type": "ICRS",
         "ra": 83.63308,
         "dec": 22.0145,
+        "proper_motion_ra": 0,
+        "proper_motion_dec": 0,
         "epoch": 2000,
         "parallax": 0.0
     },


### PR DESCRIPTION
Adding the proper motion fields to all example targets (default value of 0) avoids errors with the scheduler running in the ocs_example setup.