### PR TITLE
Fix/integration testing fixes

### DIFF
--- a/observation_portal/sciapplications/serializers.py
+++ b/observation_portal/sciapplications/serializers.py
@@ -199,8 +199,13 @@ class ScienceApplicationSerializer(serializers.ModelSerializer):
             missing_fields = {}
             for field in self.get_required_fields_for_submission(call.proposal_type):
                 empty_values = [None, '']
-                if data.get(field) in empty_values:
-                    missing_fields[field] = _('This field is required.')
+                field_is_empty = data.get(field) in empty_values
+                if field == 'pdf':
+                    if clear_pdf or field_is_empty and not getattr(self.instance, 'pdf', None):
+                        missing_fields[field] = _('A PDF is required for submission.')
+                else:
+                    if field_is_empty:
+                        missing_fields[field] = _('This field is required.')
 
             if missing_fields:
                 raise serializers.ValidationError(missing_fields)

--- a/observation_portal/sciapplications/serializers.py
+++ b/observation_portal/sciapplications/serializers.py
@@ -201,7 +201,12 @@ class ScienceApplicationSerializer(serializers.ModelSerializer):
                 empty_values = [None, '']
                 field_is_empty = data.get(field) in empty_values
                 if field == 'pdf':
-                    if clear_pdf or field_is_empty and not getattr(self.instance, 'pdf', None):
+                    if clear_pdf:
+                        missing_fields['clear_pdf'] = _(
+                            'A PDF is required for submission. If you want to clear the uploaded PDF, please '
+                            'either upload a different PDF or save the application as a draft.'
+                        )
+                    elif field_is_empty and not getattr(self.instance, 'pdf', None):
                         missing_fields[field] = _('A PDF is required for submission.')
                 else:
                     if field_is_empty:

--- a/observation_portal/sciapplications/test_api.py
+++ b/observation_portal/sciapplications/test_api.py
@@ -634,7 +634,7 @@ class TestPostCreateSciApp(DramatiqTestCase):
         del data['pdf']
         response = self.client.post(reverse('api:scienceapplications-list'), data=data)
         self.assertEqual(response.status_code, 400)
-        self.assertIn('This field is required.', response.json().get('pdf'))
+        self.assertIn('A PDF is required for submission.', response.json().get('pdf'))
 
     def test_sci_application_requires_pdf_and_abstract(self):
         data = self.sci_data.copy()
@@ -642,7 +642,7 @@ class TestPostCreateSciApp(DramatiqTestCase):
         del data['pdf']
         response = self.client.post(reverse('api:scienceapplications-list'), data=data)
         self.assertEqual(response.status_code, 400)
-        self.assertIn('This field is required.', response.json().get('pdf'))
+        self.assertIn('A PDF is required for submission.', response.json().get('pdf'))
         self.assertIn('This field is required.', response.json().get('abstract'))
 
     def test_can_save_draft_with_no_timerequests(self):

--- a/observation_portal/sciapplications/test_api.py
+++ b/observation_portal/sciapplications/test_api.py
@@ -812,6 +812,44 @@ class TestPostUpdateSciApp(DramatiqTestCase):
         self.assertEqual(coinvestigator.last_name, data['coinvestigator_set[0]last_name'])
         self.assertEqual(coinvestigator.institution, data['coinvestigator_set[0]institution'])
 
+    def test_submit_draft_that_has_pdf_saved_does_not_need_user_to_pass_in_pdf_field(self):
+        data = self.sci_data.copy()
+        uploaded_pdf = data['pdf']
+        self.sci_app.pdf = uploaded_pdf
+        self.sci_app.save()
+        del data['pdf']
+        data['status'] = ScienceApplication.SUBMITTED
+        response = self.client.put(
+            reverse('api:scienceapplications-detail', kwargs={'pk': self.sci_app.id}),
+            data=encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
+        )
+        submitted_sciapp = ScienceApplication.objects.get(pk=self.sci_app.id)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(path.basename(submitted_sciapp.pdf.name), uploaded_pdf.name)
+
+    def test_submitting_app_without_pdf_when_a_pdf_is_required_fails(self):
+        data = self.sci_data.copy()
+        data['status'] = ScienceApplication.SUBMITTED
+        del data['pdf']
+        response = self.client.put(
+            reverse('api:scienceapplications-detail', kwargs={'pk': self.sci_app.id}),
+            data=encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
+        )
+        self.assertContains(response, 'A PDF is required for submission', status_code=400)
+
+    def test_clearing_pdf_when_pdf_is_required_on_submission_fails(self):
+        data = self.sci_data.copy()
+        self.sci_app.pdf = data['pdf']
+        self.sci_app.save()
+        del data['pdf']
+        data['clear_pdf'] = True
+        data['status'] = ScienceApplication.SUBMITTED
+        response = self.client.put(
+            reverse('api:scienceapplications-detail', kwargs={'pk': self.sci_app.id}),
+            data=encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
+        )
+        self.assertContains(response, 'A PDF is required for submission', status_code=400)
+
     def test_leaving_out_a_pdf_doesnt_update_the_uploaded_pdf(self):
         uploaded_pdf = SimpleUploadedFile('app.pdf', b'123')
         self.sci_app.pdf = uploaded_pdf

--- a/observation_portal/settings.py
+++ b/observation_portal/settings.py
@@ -165,7 +165,7 @@ OAUTH2_PROVIDER = {
 }
 
 CORS_ORIGIN_ALLOW_ALL = True
-CORS_URLS_REGEX = r'^/(api|accounts)/.*$|^/o/.*'
+CORS_URLS_REGEX = r'^/(api|accounts|media)/.*$|^/o/.*'
 LOGIN_REDIRECT_URL = '/accounts/loggedinstate/'
 
 # Internationalization
@@ -187,13 +187,13 @@ DATETIME_FORMAT = 'Y-m-d H:i:s'
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_BUCKET_NAME', 'observation-portal-test-bucket')
-AWS_REGION = os.getenv('AWS_REGION', 'us-west-2')
+AWS_S3_REGION_NAME = os.getenv('AWS_REGION', 'us-west-2')
 AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID', None)
 AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY', None)
-AWS_S3_CUSTOM_DOMAIN = 's3-us-west-2.amazonaws.com/{}'.format(AWS_STORAGE_BUCKET_NAME)
 AWS_IS_GZIPPED = True
 AWS_LOCATION = os.getenv('MEDIAFILES_DIR', 'media')
 AWS_DEFAULT_ACL = None
+AWS_S3_SIGNATURE_VERSION = 's3v4'
 
 STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
 STATIC_URL = '/static/'
@@ -201,7 +201,7 @@ STATIC_ROOT = '/static/'
 STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
 STATICFILES_STORAGE = os.getenv('STATIC_STORAGE', 'django.contrib.staticfiles.storage.StaticFilesStorage')
 MEDIAFILES_DIR = os.getenv('MEDIAFILES_DIR', 'media')
-MEDIA_URL = "https://{}/{}/".format(AWS_S3_CUSTOM_DOMAIN, MEDIAFILES_DIR) if AWS_ACCESS_KEY_ID else '/media/'
+MEDIA_URL = '' if AWS_ACCESS_KEY_ID else '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 DEFAULT_FILE_STORAGE = os.getenv('MEDIA_STORAGE', 'django.core.files.storage.FileSystemStorage')
 


### PR DESCRIPTION
These are some fixes that I made after a round of final testing of the new frontend.
- Updated some settings used by `django-storages` to fix genenerating s3 urls. The sciapps pages previously used a custom templatetag to generate the presigned s3 url for a user to access, but actually `django-storages` generates one for you automatically when the `url` prop of a `FileField` is accessed, as long as the settings are set up correctly. I couldn't see why we needed to set our own custom domain (the `AWS_S3_CUSTOM_DOMAIN` setting) and with it removed, the presigned url gets generated correctly and uploads work. But let me know if you remember why we needed that setting.
- Fixed a validation issue with sciapp submissions to allow a user to submit a sciapp draft that they had previously saved that already has a PDF associated with it, without requiring them to include that same PDF in the submission request body. I also added a check to prevent a user from clearing the PDF that they had previously uploaded when submitting a draft, if that sciapp requires a PDF.