### PR TITLE
Fix/separate frontend deploy fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ media/
 .tox/
 .git/
 .venv/
+.env/
 **/*.swp
 **/*.pyc
 **/__pycache__

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Optional prerequisites can be skipped for reduced functionality.
 | ---------------------- | ----------------------- | ------------------------------------------------------------------- | ------------------------------------------------------- |
 | General                | `DEBUG`                 | Whether the application should run using Django's debug mode        | `False`                                                 |
 |                        | `SECRET_KEY`            | The secret key used for sessions                                    | _`random characters`_                                   |
-|                        | `CSRF_TRUSTED_ORIGINS`  | List of trusted origins allowed for CSRF                            | `None`
+|                        | `CSRF_TRUSTED_ORIGINS`  | Comma separated list of trusted origins allowed for CSRF            | `None`
 | Database               | `DB_NAME`               | The name of the database                                            | `observation_portal`                                    |
 |                        | `DB_USER`               | The database user                                                   | `postgres`                                              |
 |                        | `DB_PASSWORD`           | The database password                                               | _`Empty string`_                                        |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Optional prerequisites can be skipped for reduced functionality.
 | ---------------------- | ----------------------- | ------------------------------------------------------------------- | ------------------------------------------------------- |
 | General                | `DEBUG`                 | Whether the application should run using Django's debug mode        | `False`                                                 |
 |                        | `SECRET_KEY`            | The secret key used for sessions                                    | _`random characters`_                                   |
+|                        | `CSRF_TRUSTED_ORIGINS`  | List of trusted origins allowed for CSRF                            | `None`
 | Database               | `DB_NAME`               | The name of the database                                            | `observation_portal`                                    |
 |                        | `DB_USER`               | The database user                                                   | `postgres`                                              |
 |                        | `DB_PASSWORD`           | The database password                                               | _`Empty string`_                                        |

--- a/observation_portal/settings.py
+++ b/observation_portal/settings.py
@@ -13,6 +13,15 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 import os
 from lcogt_logging import LCOGTFormatter
 
+
+def get_list_from_env(variable, default=None):
+    value_as_list = []
+    value = os.getenv(variable, default)
+    if value:
+        value_as_list = value.strip(', ').replace(' ', '').split(',')
+    return value_as_list
+
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -166,6 +175,7 @@ OAUTH2_PROVIDER = {
 
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r'^/(api|accounts|media)/.*$|^/o/.*'
+CSRF_TRUSTED_ORIGINS = get_list_from_env('CSRF_TRUSTED_ORIGINS')
 LOGIN_REDIRECT_URL = '/accounts/loggedinstate/'
 
 # Internationalization

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
   </head>
   <body>
-  {% block content %}
-  {% endblock %}
+    <div>
+    {% block content %}
+    {% endblock %}
+    </div>
   </body>
 </html>


### PR DESCRIPTION
A couple of minor fixes from deploying the separate frontend:
- Needed to add a configurable `CSRF_TRUSTED_HOSTS` to allow the forms that are passed through to the frontend to work. I hadn't caught this before since the host configured in the ingress of the dev deploy and the hostname of the dev deploy pod were both the same, so there was no issue. However, with the prod deploy, the ingress host is different from the pod hostname so this is needed to let the frontend submit a form.
- Added a div wrapping the content of the base HTML template. This template is used for the various registration forms, and the library that I am using in the frontend to extract/ display the form in the frontend will only be able to extract the form if the element is not at the top level.