### PR TITLE
Validate that the defocus value, when passed in, is a number

### DIFF
--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -187,8 +187,10 @@ class InstrumentConfigSerializer(ExtraParamsFormatter, serializers.ModelSerializ
                 'Currently only square binnings are supported. Please submit with bin_x == bin_y'
             ))
 
+        # TODO: These checks on extra_params will either go in a subclassed serializer or in cerberus validation schema
+        extra_params = data.get('extra_params', {})
         extra_param_max_exp_time = 0
-        for field, value in data.get('extra_params', {}).items():
+        for field, value in extra_params.items():
             try:
                 if 'exposure_time' in field and float(value) > extra_param_max_exp_time:
                     extra_param_max_exp_time = float(value)
@@ -196,6 +198,12 @@ class InstrumentConfigSerializer(ExtraParamsFormatter, serializers.ModelSerializ
                 pass
         if extra_param_max_exp_time > 0:
             data['exposure_time'] = extra_param_max_exp_time
+
+        if 'defocus' in extra_params:
+            try:
+                float(extra_params['defocus'])
+            except (ValueError, TypeError):
+                raise serializers.ValidationError(_('Defocus must be a number'))
 
         return data
 

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -1410,6 +1410,34 @@ class TestConfigurationApi(SetTimeMixin, APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('exposure_time', str(response.content))
 
+    def test_bad_defocus_values_must_not_be_submitted(self):
+        bad_data = self.generic_payload.copy()
+        bad_values = ['2mm', '']
+        for bad_value in bad_values:
+            with self.subTest(bad_value=bad_value):
+                bad_data['requests'][0]['configurations'][0]['instrument_configs'][0]['extra_params'] = {
+                    'defocus': bad_value
+                }
+                response = self.client.post(reverse('api:request_groups-list'), data=bad_data)
+                self.assertEqual(response.status_code, 400)
+                self.assertIn('Defocus', str(response.content))
+
+    def test_defocus_as_a_number_successfully_submits(self):
+        good_data = self.generic_payload.copy()
+        good_values = [2, '2']
+        expected_submitted_defocus = 2
+        for good_value in good_values:
+            with self.subTest(good_value=good_value):
+                good_data['requests'][0]['configurations'][0]['instrument_configs'][0]['extra_params'] = {
+                    'defocus': good_value
+                }
+                r = self.client.post(reverse('api:request_groups-list'), data=good_data)
+                self.assertEqual(r.status_code, 201)
+                self.assertEqual(
+                    r.json()['requests'][0]['configurations'][0]['instrument_configs'][0]['extra_params']['defocus'],
+                    expected_submitted_defocus
+                )
+
     def test_default_guide_mode_for_spectrograph(self):
         good_data = self.generic_payload.copy()
         response = self.client.post(reverse('api:request_groups-list'), data=good_data)


### PR DESCRIPTION
Check that the value for defocus that is passed in is a number. We ultimately want to add a validation schema to configdb under instrument types that can then be used to validate the extra_params of instrument_configs, and then use that to validate all the values passed in. However, this is just to make sure that a user does not pass in an invalid value in the meantime, until we start on the stories to further generalize the portal.