### PR TITLE
Multiple target soar

### DIFF
--- a/observation_portal/common/rise_set_utils.py
+++ b/observation_portal/common/rise_set_utils.py
@@ -30,7 +30,6 @@ def get_largest_interval(intervals_by_site):
     return largest_interval
 
 
-# TODO: rewrite to handle multiple targets per request
 def get_rise_set_intervals_by_site(request: dict, only_schedulable: bool = False) -> dict:
     """Get rise_set intervals by site for a request
 

--- a/observation_portal/common/rise_set_utils.py
+++ b/observation_portal/common/rise_set_utils.py
@@ -60,6 +60,7 @@ def get_rise_set_intervals_by_site(request: dict, only_schedulable: bool = False
             for window in request['windows']:
                 visibility = get_rise_set_visibility(rise_set_site, window['start'], window['end'], site_details[site])
                 target_intervals = Intervals()
+                first_target = True
                 for target_constraints in unique_targets_constraints:
                     (target, constraints) = json.loads(target_constraints)
                     rise_set_target = get_rise_set_target(target)
@@ -72,7 +73,8 @@ def get_rise_set_intervals_by_site(request: dict, only_schedulable: bool = False
                             )
                         )
                         # We only want times when all targets are visible to keep things simple
-                        if target_intervals.is_empty():
+                        if first_target:
+                            first_target = False
                             target_intervals = Intervals(rs_interval)
                         else:
                             target_intervals = Intervals(rs_interval).intersect([target_intervals])

--- a/observation_portal/common/test_data/configdb.json
+++ b/observation_portal/common/test_data/configdb.json
@@ -1560,6 +1560,140 @@
               ]
             }
           ]
+        },
+        {
+          "code": "domf",
+          "telescope_set": [
+            {
+              "code": "1m0a",
+              "name": "1 Meter",
+              "lat": -32.3805542,
+              "long": 20.8100352,
+              "horizon": 15.0,
+              "ha_limit_pos": 4.6,
+              "ha_limit_neg": -4.6,
+              "zenith_blind_spot": 0.0,
+              "slew_rate": 0.0,
+              "minimum_slew_overhead": 2.0,
+              "maximum_slew_overhead": 2.0,
+              "instrument_change_overhead": 30.0,
+              "instrument_set": [
+                {
+                  "state": "SCHEDULABLE",
+                  "code": "os01",
+                  "autoguider_camera": {
+                    "code": "sx01",
+                    "camera_type": {
+                      "code": "1M0-SCICAM-AG",
+                      "allow_self_guiding": true
+                    }
+                  },
+                  "instrument_type": {
+                    "code": "1M0-SCICAM-SOAR",
+                    "name": "1M0-SCICAM-SOAR",
+                    "allow_self_guiding": true,
+                    "configuration_types": [
+                      "EXPOSE",
+                      "REPEAT_EXPOSE",
+                      "BIAS",
+                      "DARK",
+                      "SCRIPT",
+                      "SKY_FLAT"
+                    ],
+                    "default_acceptability_threshold": 100,
+                    "config_change_time": 0,
+                    "acquire_exposure_time": 0,
+                    "front_padding": 90,
+                    "fixed_overhead_per_exposure": 1,
+                    "mode_types": [
+                      {
+                        "type": "readout",
+                        "default": "1m0_soar_2",
+                        "modes": [
+                          {
+                            "code": "1m0_soar_1",
+                            "overhead": 35.0,
+                            "validation_schema": {
+                              "bin_x": {"type": "integer", "allowed": [1], "default": 1},
+                              "bin_y": {"type": "integer", "allowed": [1], "default": 1}
+                            }
+                          },
+                          {
+                            "code": "1m0_soar_2",
+                            "overhead": 14.5,
+                            "validation_schema": {
+                              "bin_x": {"type": "integer", "allowed": [2], "default": 2},
+                              "bin_y": {"type": "integer", "allowed": [2], "default": 2}
+                            }
+                          },
+                          {
+                            "code": "1m0_soar_3",
+                            "overhead": 11.5,
+                            "validation_schema": {
+                              "bin_x": {"type": "integer", "allowed": [3], "default": 3},
+                              "bin_y": {"type": "integer", "allowed": [3], "default": 3}
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "acquisition",
+                        "default": "OFF",
+                        "modes": [
+                          {
+                            "code": "OFF",
+                            "overhead": 0.0,
+                            "validation_schema": {}
+                          }
+                        ]
+                      },
+                      {
+                        "type": "guiding",
+                        "default": "OFF",
+                        "modes": [
+                          {
+                            "code": "OFF",
+                            "overhead": 0.0,
+                            "validation_schema": {}
+                          },
+                          {
+                            "code": "ON",
+                            "overhead": 0.0,
+                            "validation_schema": {}
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "science_cameras": [{
+                    "code": "so01",
+                    "camera_type": {
+                      "code": "1M0-SCICAM-SOAR",
+                      "name": "1M0-SCICAM-SOAR",
+                      "pixels_x": 1000,
+                      "pixels_y": 1000,
+                      "max_rois": 0
+                    },
+                    "optical_element_groups": [
+                      {
+                        "type": "filters",
+                        "element_change_overhead": 2,
+                        "optical_elements": [
+                          {
+                            "name": "Air",
+                            "code": "air",
+                            "schedulable": false
+                          }
+                        ],
+                        "default": "air"
+                      }
+                    ]
+                  }],
+                  "__str__": "tst.dome.1m0a.so01-os01"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -579,7 +579,7 @@ class RequestSerializer(serializers.ModelSerializer):
         # Set the relative priority of molecules in order
         for i, configuration in enumerate(value):
             configuration['priority'] = i + 1
-            if configuration['constraints'] != constraints:
+            if 'SOAR' not in configuration['instrument_type'].upper() and configuration['constraints'] != constraints:
                 raise serializers.ValidationError(_(
                     'Currently only a single constraints per Request is supported. This restriction will be '
                     'lifted in the future.'

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -798,7 +798,7 @@ class RequestGroupSerializer(serializers.ModelSerializer):
 
                     # For non-DIRECT observations, only allow a single target
                     # TODO: Remove this check once we support multiple targets/constraints
-                    if config['target'] != target:
+                    if 'SOAR' not in config['instrument_type'].upper() and config['target'] != target:
                         raise serializers.ValidationError(_(
                             'Currently only a single target per Request is supported. This restriction will be lifted '
                             'in the future.'

--- a/observation_portal/requestgroups/test/test_request_utils.py
+++ b/observation_portal/requestgroups/test/test_request_utils.py
@@ -356,7 +356,7 @@ class TestMultipleTargetRequestIntervals(BaseSetupRequest):
 
     def test_request_intervals_for_multiple_targets_empty_if_one_is_empty(self):
         request_dict = self.request.as_dict()
-        
+
         # now create get the intervals for a request with the second target that isn't visible
         configuration2 = deepcopy(request_dict['configurations'][0])
         configuration2['target']['dec'] = 70.0  # change the DEC so the target isn't visible

--- a/observation_portal/requestgroups/test/test_request_utils.py
+++ b/observation_portal/requestgroups/test/test_request_utils.py
@@ -306,24 +306,6 @@ class TestRequestIntervals(BaseSetupRequest):
 
 
 class TestMultipleTargetRequestIntervals(BaseSetupRequest):
-    def setUp(self):
-        super().setUp()
-        # Set up a second configuration with a different Target
-        # self.configuration2 = mixer.blend(
-        #     Configuration, request=self.request, instrument_type='1M0-SCICAM-SBIG', type='EXPOSE'
-        # )
-        # self.instrument_config = mixer.blend(
-        #     InstrumentConfig, configuration=self.configuration2, exposure_time=600, exposure_count=2,
-        #     optical_elements={'filter': 'blah'}, bin_x=2, bin_y=2
-        # )
-        # self.acquisition_config = mixer.blend(AcquisitionConfig, configuration=self.configuration2)
-        # self.guiding_config = mixer.blend(GuidingConfig, configuration=self.configuration2)
-        # mixer.blend(
-        #     Target, configuration=self.configuration2, type='ICRS', ra=82, dec=-33, proper_motion_ra=0.0,
-        #     proper_motion_dec=0.0
-        # )
-        # mixer.blend(Constraints, configuration=self.configuration2)
-
     def test_request_intervals_for_multiple_targets_intersected(self):
         request_dict = self.request.as_dict()
         intervals = get_filtered_rise_set_intervals_by_site(request_dict).get('tst', [])

--- a/observation_portal/requestgroups/test/test_request_utils.py
+++ b/observation_portal/requestgroups/test/test_request_utils.py
@@ -2,7 +2,10 @@ from django.utils import timezone
 from django.test import TestCase
 from mixer.backend.django import mixer
 from datetime import datetime
+from copy import deepcopy
 from unittest.mock import patch
+
+from time_intervals.intervals import Intervals
 
 from observation_portal.requestgroups.request_utils import (get_airmasses_for_request_at_sites, get_telescope_states_for_request,
                                                             get_filtered_rise_set_intervals_by_site)
@@ -300,6 +303,74 @@ class TestRequestIntervals(BaseSetupRequest):
                             datetime(2016, 10, 8, 0, 0, tzinfo=timezone.utc))]
 
         self.assertEqual(intervals, truth_intervals)
+
+
+class TestMultipleTargetRequestIntervals(BaseSetupRequest):
+    def setUp(self):
+        super().setUp()
+        # Set up a second configuration with a different Target
+        # self.configuration2 = mixer.blend(
+        #     Configuration, request=self.request, instrument_type='1M0-SCICAM-SBIG', type='EXPOSE'
+        # )
+        # self.instrument_config = mixer.blend(
+        #     InstrumentConfig, configuration=self.configuration2, exposure_time=600, exposure_count=2,
+        #     optical_elements={'filter': 'blah'}, bin_x=2, bin_y=2
+        # )
+        # self.acquisition_config = mixer.blend(AcquisitionConfig, configuration=self.configuration2)
+        # self.guiding_config = mixer.blend(GuidingConfig, configuration=self.configuration2)
+        # mixer.blend(
+        #     Target, configuration=self.configuration2, type='ICRS', ra=82, dec=-33, proper_motion_ra=0.0,
+        #     proper_motion_dec=0.0
+        # )
+        # mixer.blend(Constraints, configuration=self.configuration2)
+
+    def test_request_intervals_for_one_week(self):
+        request_dict = self.request.as_dict()
+        intervals = get_filtered_rise_set_intervals_by_site(request_dict).get('tst', [])
+        truth_intervals = [
+            (datetime(2016, 10, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(2016, 10, 1, 3, 20, 31, 366820, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 1, 19, 13, 14, 944205, tzinfo=timezone.utc),
+            datetime(2016, 10, 2, 3, 19, 9, 181040, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 2, 19, 9, 19, 241762, tzinfo=timezone.utc),
+            datetime(2016, 10, 3, 3, 17, 47, 117329, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 3, 19, 5, 23, 539011, tzinfo=timezone.utc),
+            datetime(2016, 10, 4, 3, 16, 25, 202612, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 4, 19, 1, 27, 835928, tzinfo=timezone.utc),
+            datetime(2016, 10, 5, 3, 15, 3, 464340, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 5, 18, 57, 32, 132481, tzinfo=timezone.utc),
+            datetime(2016, 10, 6, 3, 12, 5, 895932, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 6, 18, 53, 36, 428629, tzinfo=timezone.utc),
+            datetime(2016, 10, 7, 3, 8, 10, 183626, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 7, 18, 49, 40, 724307, tzinfo=timezone.utc),
+            datetime(2016, 10, 8, 0, 0, tzinfo=timezone.utc))
+        ]
+
+        self.assertEqual(intervals, truth_intervals)
+        # now create get the intervals for a request with the second target
+        configuration2 = deepcopy(request_dict['configurations'][0])
+        configuration2['target']['ra'] = 85.0  # change the RA so the target has different visibility
+        request_dict2 = deepcopy(request_dict)
+        request_dict2['configurations'][0] = configuration2
+        intervals2 = get_filtered_rise_set_intervals_by_site(request_dict2).get('tst', [])
+        truth_intervals2 = [
+            (datetime(2016, 10, 1, 0, 0, tzinfo=timezone.utc), datetime(2016, 10, 1, 3, 20, 31, 366820, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 1, 23, 24, 4, 392218, tzinfo=timezone.utc), datetime(2016, 10, 2, 3, 19, 9, 181040, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 2, 23, 20, 8, 717423, tzinfo=timezone.utc), datetime(2016, 10, 3, 3, 17, 47, 117329, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 3, 23, 16, 13, 42308, tzinfo=timezone.utc), datetime(2016, 10, 4, 3, 16, 25, 202612, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 4, 23, 12, 17, 366627, tzinfo=timezone.utc), datetime(2016, 10, 5, 3, 15, 3, 464340, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 5, 23, 8, 21, 690204, tzinfo=timezone.utc), datetime(2016, 10, 6, 3, 13, 41, 930536, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 6, 23, 4, 26, 12943, tzinfo=timezone.utc), datetime(2016, 10, 7, 3, 12, 20, 629833, tzinfo=timezone.utc)),
+            (datetime(2016, 10, 7, 23, 0, 30, 334810, tzinfo=timezone.utc), datetime(2016, 10, 8, 0, 0, tzinfo=timezone.utc)),
+        ]
+        self.assertEqual(intervals2, truth_intervals2)
+
+        # now get the intervals for both targets combined in the request and verify they are intersected
+        request_dict3 = deepcopy(request_dict)
+        request_dict3['configurations'].append(configuration2)
+        intervals3 = get_filtered_rise_set_intervals_by_site(request_dict3).get('tst', [])
+        truth_intervals_combined = Intervals(truth_intervals).intersect([Intervals(truth_intervals2)]).toTupleList()
+        self.assertEqual(intervals3, truth_intervals_combined)
 
 
 class TestRequestAirmass(BaseSetupRequest):

--- a/observation_portal/requestgroups/test/test_request_utils.py
+++ b/observation_portal/requestgroups/test/test_request_utils.py
@@ -354,6 +354,25 @@ class TestMultipleTargetRequestIntervals(BaseSetupRequest):
         truth_intervals_combined = Intervals(truth_intervals).intersect([Intervals(truth_intervals2)]).toTupleList()
         self.assertEqual(intervals3, truth_intervals_combined)
 
+    def test_request_intervals_for_multiple_targets_empty_if_one_is_empty(self):
+        request_dict = self.request.as_dict()
+        
+        # now create get the intervals for a request with the second target that isn't visible
+        configuration2 = deepcopy(request_dict['configurations'][0])
+        configuration2['target']['dec'] = 70.0  # change the DEC so the target isn't visible
+        request_dict2 = deepcopy(request_dict)
+        request_dict2['configurations'][0] = configuration2
+        intervals = get_filtered_rise_set_intervals_by_site(request_dict2).get('tst', [])
+        truth_intervals = [
+        ]
+        self.assertEqual(intervals, truth_intervals)
+
+        # now get the intervals for both targets combined in the request and verify they are intersected and empty
+        request_dict3 = deepcopy(request_dict)
+        request_dict3['configurations'].append(configuration2)
+        intervals3 = get_filtered_rise_set_intervals_by_site(request_dict3).get('tst', [])
+        self.assertEqual(intervals3, [])
+
     def test_airmass_for_multiple_targets_averaged(self):
         request_dict = self.request.as_dict()
         airmasses = get_airmasses_for_request_at_sites(request_dict)

--- a/observation_portal/sciapplications/test_admin.py
+++ b/observation_portal/sciapplications/test_admin.py
@@ -13,13 +13,13 @@ from observation_portal.sciapplications.models import ScienceApplication, Call, 
 def order_mail_invite_then_approval(mailbox):
     ordered_mailbox = []
     # First look for any proposal invite emails and add them
-    for mail in mailbox:
-        if 'You have been added' in mail.subject:
-            ordered_mailbox.append(mail)
+    for item in mailbox:
+        if 'You have been added' in item.subject:
+            ordered_mailbox.append(item)
     # Then look for an proposal approval emails and add them
-    for mail in mailbox:
-        if 'has been approved' in mail.subject:
-            ordered_mailbox.append(mail)
+    for item in mailbox:
+        if 'has been approved' in item.subject:
+            ordered_mailbox.append(item)
 
     return ordered_mailbox
 


### PR DESCRIPTION
Like we discussed, this is doing a simple intersection of rise-sets for each target to get total request rise-set windows. It then uses that and averages the airmass values of all targets and constraints within the rise-set windows. I hate adding the SOAR specific code in here, but we will clean it up soon with the stories we have planned.