### PR TITLE
Fix/ Soar blue spectrograph classification

### DIFF
--- a/observation_portal/common/configdb.py
+++ b/observation_portal/common/configdb.py
@@ -593,7 +593,7 @@ class ConfigDB(object):
     @staticmethod
     def is_spectrograph(instrument_type):
         return instrument_type.upper() in ['2M0-FLOYDS-SCICAM', '0M8-NRES-SCICAM', '1M0-NRES-SCICAM',
-                                           '1M0-NRES-COMMISSIONING', 'SOAR_GHTS_REDCAM']
+                                           '1M0-NRES-COMMISSIONING', 'SOAR_GHTS_REDCAM', 'SOAR_GHTS_BLUECAM']
 
     @staticmethod
     def is_nres(instrument_type):


### PR DESCRIPTION
Added `SOAR_GHTS_BLUECAM ` to the list of spectrograph instruments in the `is_spectrograph()` method so that it is classified correctly in the `/api/instruments/` response.

In the near future we plan on adding a field to ConfigDB classifying an instrument as a spectrograph or not, so we won't need to maintain this list for much longer.