### PR TITLE
Re-add back the exposure time checks with a way to override in serial…

### DIFF
--- a/observation_portal/requestgroups/duration_utils.py
+++ b/observation_portal/requestgroups/duration_utils.py
@@ -200,7 +200,7 @@ def get_complete_configurations_duration(configurations_list, start_time, priori
             # Certain Configuration Types for certain Instrument Types will have a non-zero config_change_overhead.
             # For instance, this could account for Lamp startup times when first switching to an ARC or LAMP_FLAT configuration.
             if previous_conf_type != configuration_dict['type']:
-                duration += configuration_types[configuration_dict['type']]['config_change_overhead']
+                duration += configuration_types.get(configuration_dict['type'], {}).get('config_change_overhead', 0.0)
             previous_conf_type = configuration_dict['type']
         else:
             previous_conf_type = configuration_dict['type']

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -221,7 +221,6 @@ class RegionOfInterestSerializer(serializers.ModelSerializer):
 
 
 class InstrumentConfigSerializer(ExtraParamsFormatter, serializers.ModelSerializer):
-    exposure_time = serializers.FloatField(required=False, allow_null=True)
     rois = import_string(settings.SERIALIZERS['requestgroups']['RegionOfInterest'])(many=True, required=False)
 
     class Meta:
@@ -330,11 +329,6 @@ class ConfigurationSerializer(ExtraParamsFormatter, serializers.ModelSerializer)
             )
         return value
 
-    def instrument_type_requires_exp_time(self, instrument_type):
-        # for use in overriding the serializer to require exposure time to be set in certain
-        # instrument types. Default is to require it set for all instrument types.
-        return True
-
     def validate(self, data):
         # TODO: Validate the guiding optical elements on the guiding instrument types
         instrument_type = data['instrument_type']
@@ -353,12 +347,12 @@ class ConfigurationSerializer(ExtraParamsFormatter, serializers.ModelSerializer)
             raise serializers.ValidationError(_(
                 f'configuration type {data["type"]} is not valid for instrument type {instrument_type}'
             ))
-        elif not configuration_types[data['type']]['schedulable']:
+        elif not configuration_types.get(data['type'], {}).get('schedulable', False):
             raise serializers.ValidationError(_(
                 f'configuration type {data["type"]} is not schedulable for instrument type {instrument_type}'
             ))
 
-        if configuration_types[data['type']]['force_acquisition_off']:
+        if configuration_types.get(data['type'], {}).get('force_acquisition_off', False):
             # These types of observations should only ever be set to guiding mode OFF, but the acquisition modes for
             # spectrographs won't necessarily have that mode. Force OFF here.
             data['acquisition_config']['mode'] = AcquisitionConfig.OFF
@@ -417,7 +411,7 @@ class ConfigurationSerializer(ExtraParamsFormatter, serializers.ModelSerializer)
 
             # Also check that any optical element group in configdb is specified in the request unless this configuration type does
             # not require optical elements to be set. This will typically be the case for certain configuration types, like BIAS or DARK.
-            if configuration_types[data['type']]['requires_optical_elements']:
+            if configuration_types.get(data['type'], {}).get('requires_optical_elements', True):
                 for oe_type in available_optical_elements.keys():
                     singular_type = oe_type[:-1] if oe_type.endswith('s') else oe_type
                     if singular_type not in instrument_config.get('optical_elements', {}):
@@ -464,14 +458,6 @@ class ConfigurationSerializer(ExtraParamsFormatter, serializers.ModelSerializer)
                 )
                 instrument_config = exposure_mode_validation_helper.validate(instrument_config)
                 data['instrument_configs'][i] = instrument_config
-
-            if self.instrument_type_requires_exp_time(instrument_type):
-                if instrument_config.get('exposure_time', None) is None:
-                    raise serializers.ValidationError({'instrument_configs': [{'exposure_time': [_('This value cannot be null.')]}]})
-                if isnan(instrument_config.get('exposure_time')):
-                    raise serializers.ValidationError({'instrument_configs': [{'exposure_time': [_('A valid number is required.')]}]})
-                if instrument_config['exposure_time'] < 0:
-                    raise serializers.ValidationError({'instrument_configs': [{'exposure_time': [_('This value cannot be negative.')]}]})
 
         if data['type'] == 'SCRIPT':
             if (

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -1412,13 +1412,6 @@ class TestConfigurationApi(SetTimeMixin, APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('exposure_time', str(response.content))
 
-    def test_must_have_non_nan_exposure_time(self):
-        bad_data = self.generic_payload.copy()
-        bad_data['requests'][0]['configurations'][0]['instrument_configs'][0]['exposure_time'] = 'nan'
-        response = self.client.post(reverse('api:request_groups-list'), data=bad_data)
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('exposure_time', str(response.content))
-
     def test_bad_defocus_values_must_not_be_submitted(self):
         bad_data = self.generic_payload.copy()
         bad_values = ['2mm', '', 5.1, -6.5]


### PR DESCRIPTION
…izer

This is to address those error emails we received tonight - which occur when someone is submitting a muscat observation via the frontend. The frontend temporarily starts the exposure_time field value as null/None, which triggers a 500 error right now. I didn't realize it was ever null, and didn't see it in testing because its just a transient error and goes away once you fill in all the exposure time fields. I thought I had done something clever moving the exposure time checks out of here and adding them in the LCO serializers, but I think I just created some corner cases like this, so I am re-adding the previous exposure time checking back to the code. There is also a new over-rideable method to get whether an instrument_type should check the exposure time or not. 