### PR TITLE
Change the telescope_class filter on schedulable_requests to be teles…

### DIFF
--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -2339,13 +2339,13 @@ class TestSchedulableRequestsApi(SetTimeMixin, APITestCase):
         # Now get the requests filtered by each telescope_class and ensure its filtered properly
         rg_ids_numbers_1m0 = [rg.id for rg in self.rgs]        
         rg_ids_numbers_2m0 = [rg.id for rg in rgs_2m0]
-        response_1m0 = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_class=1m0')
+        response_1m0 = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_classes=1m0')
         self.assertEqual(response_1m0.status_code, 200)
         self.assertEqual(len(response_1m0.json()), 10)
         for rg in response_1m0.json():
             self.assertIn(rg['id'], rg_ids_numbers_1m0)
 
-        response_2m0 = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_class=2m0')
+        response_2m0 = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_classes=2m0')
         self.assertEqual(response_2m0.status_code, 200)
         self.assertEqual(len(response_2m0.json()), 3)
         for rg in response_2m0.json():
@@ -2356,6 +2356,13 @@ class TestSchedulableRequestsApi(SetTimeMixin, APITestCase):
         self.assertEqual(len(response_no_filter.json()), 13)
         combined_rg_ids = rg_ids_numbers_1m0 + rg_ids_numbers_2m0
         for rg in response_no_filter.json():
+            self.assertIn(rg['id'], combined_rg_ids)
+
+        # Specify both telescope classes and ensure multi-select works as well
+        response_both_filter = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_classes=2m0,1m0')
+        self.assertEqual(response_both_filter.status_code, 200)
+        self.assertEqual(len(response_both_filter.json()), 13)
+        for rg in response_both_filter.json():
             self.assertIn(rg['id'], combined_rg_ids)
 
     def test_dont_get_requests_in_terminal_states(self, modify_mock):

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -2339,13 +2339,13 @@ class TestSchedulableRequestsApi(SetTimeMixin, APITestCase):
         # Now get the requests filtered by each telescope_class and ensure its filtered properly
         rg_ids_numbers_1m0 = [rg.id for rg in self.rgs]        
         rg_ids_numbers_2m0 = [rg.id for rg in rgs_2m0]
-        response_1m0 = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_classes=1m0')
+        response_1m0 = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_class=1m0')
         self.assertEqual(response_1m0.status_code, 200)
         self.assertEqual(len(response_1m0.json()), 10)
         for rg in response_1m0.json():
             self.assertIn(rg['id'], rg_ids_numbers_1m0)
 
-        response_2m0 = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_classes=2m0')
+        response_2m0 = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_class=2m0')
         self.assertEqual(response_2m0.status_code, 200)
         self.assertEqual(len(response_2m0.json()), 3)
         for rg in response_2m0.json():
@@ -2359,7 +2359,7 @@ class TestSchedulableRequestsApi(SetTimeMixin, APITestCase):
             self.assertIn(rg['id'], combined_rg_ids)
 
         # Specify both telescope classes and ensure multi-select works as well
-        response_both_filter = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_classes=2m0,1m0')
+        response_both_filter = self.client.get(reverse('api:request_groups-schedulable-requests') + '?telescope_class=2m0&telescope_class=1m0')
         self.assertEqual(response_both_filter.status_code, 200)
         self.assertEqual(len(response_both_filter.json()), 13)
         for rg in response_both_filter.json():

--- a/observation_portal/requestgroups/viewsets.py
+++ b/observation_portal/requestgroups/viewsets.py
@@ -77,9 +77,7 @@ class RequestGroupViewSet(ListAsDictMixin, viewsets.ModelViewSet):
         current_semester = Semester.current_semesters().first()
         start = parse(request.query_params.get('start', str(current_semester.start))).replace(tzinfo=timezone.utc)
         end = parse(request.query_params.get('end', str(current_semester.end))).replace(tzinfo=timezone.utc)
-        telescope_classes = request.query_params.get('telescope_classes')
-        if telescope_classes:
-            telescope_classes = telescope_classes.split(',')
+        telescope_classes = request.query_params.getlist('telescope_class')
         # Schedulable requests are not in a terminal state, are part of an active proposal,
         # and have a window within this semester
         instrument_config_query = InstrumentConfig.objects.prefetch_related('rois')

--- a/observation_portal/requestgroups/viewsets.py
+++ b/observation_portal/requestgroups/viewsets.py
@@ -77,7 +77,9 @@ class RequestGroupViewSet(ListAsDictMixin, viewsets.ModelViewSet):
         current_semester = Semester.current_semesters().first()
         start = parse(request.query_params.get('start', str(current_semester.start))).replace(tzinfo=timezone.utc)
         end = parse(request.query_params.get('end', str(current_semester.end))).replace(tzinfo=timezone.utc)
-        telescope_class = request.query_params.get('telescope_class')
+        telescope_classes = request.query_params.get('telescope_classes')
+        if telescope_classes:
+            telescope_classes = telescope_classes.split(',')
         # Schedulable requests are not in a terminal state, are part of an active proposal,
         # and have a window within this semester
         instrument_config_query = InstrumentConfig.objects.prefetch_related('rois')
@@ -101,8 +103,8 @@ class RequestGroupViewSet(ListAsDictMixin, viewsets.ModelViewSet):
             Prefetch('proposal', queryset=Proposal.objects.only('id').all()),
             Prefetch('submitter', queryset=User.objects.only('username', 'is_staff').all())
         ).distinct()
-        if telescope_class:
-            queryset = queryset.filter(requests__location__telescope_class__iexact=telescope_class)
+        if telescope_classes:
+            queryset = queryset.filter(requests__location__telescope_class__in=telescope_classes)
 
         # queryset now contains all the schedulable URs and their associated requests and data
         # Check that each request time available in its proposal still


### PR DESCRIPTION
…cope_class and take multiple input params

This change is to support scheduling on more than one telescope_class but not all with the scheduler.