### PR TITLE
Support cors_origin_whitelist setting

### DIFF
--- a/observation_portal/settings.py
+++ b/observation_portal/settings.py
@@ -182,7 +182,9 @@ OAUTH2_PROVIDER = {
 }
 
 CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True
 CORS_URLS_REGEX = r'^/(api|accounts|media)/.*$|^/o/.*'
+CORS_ORIGIN_WHITELIST = get_list_from_env('CORS_ORIGIN_WHITELIST')
 CSRF_TRUSTED_ORIGINS = get_list_from_env('CSRF_TRUSTED_ORIGINS')
 LOGIN_REDIRECT_URL = '/accounts/loggedinstate/'
 


### PR DESCRIPTION
Allow users to set the cors_origin_whitelist with an environment variable, just like the csrf_trusted_origins setting.

This is needed in order to run the ocs_example locally with a frontend that talks to the backend, without running into cors errors in the browser. It basically implements [these instructions](https://github.com/LCOGT/observation-portal-frontend#local-development) from the observation-portal-frontend. 