### PR TITLE
two potential fixes for the failing time allocation deletion unit test

### DIFF
--- a/observation_portal/proposals/tests.py
+++ b/observation_portal/proposals/tests.py
@@ -10,7 +10,6 @@ from django_dramatiq.test import DramatiqTestCase
 
 from observation_portal.proposals.models import ProposalInvite, Proposal, Membership, ProposalNotification, TimeAllocation, Semester
 from observation_portal.requestgroups.models import RequestGroup, Configuration, InstrumentConfig, Window
-from observation_portal.requestgroups import duration_utils
 from observation_portal.accounts.models import Profile
 from observation_portal.common.test_helpers import create_simple_requestgroup
 from observation_portal.proposals.tasks import time_allocation_reminder
@@ -312,15 +311,22 @@ class TestProposalAdmin(TestCase):
         for proposal in self.proposals:
             self.assertEqual(Proposal.objects.get(pk=proposal.id).active, True)
 
-    def test_clean_time_allocation(self):
+    def test_clean_time_allocation_time_change_succeeds(self):
         ta_dict = self.time_allocation.as_dict()
+        ta_dict['std_allocation'] = ta_dict['std_allocation'] + 10.0
         taf = TimeAllocationForm(data=ta_dict, instance=self.time_allocation)
         self.assertTrue(taf.is_valid())
 
-        # Now attempt to change the semester and see it fail
-        ta_dict2 = self.time_allocation.as_dict()
-        ta_dict2['semester'] = self.future_semester.id
-        taf2 = TimeAllocationForm(data=ta_dict2, instance=self.time_allocation)
-        self.assertFalse(taf2.is_valid())
-        self.assertIn("Cannot change TimeAllocation", taf2.non_field_errors()[0])
-        duration_utils.semesters = None  # Clear the global semester variable that seems to be bad after this test
+    def test_clean_time_allocation_semester_change_fails(self):
+        ta_dict = self.time_allocation.as_dict()
+        ta_dict['semester'] = self.future_semester.id
+        taf = TimeAllocationForm(data=ta_dict, instance=self.time_allocation)
+        self.assertFalse(taf.is_valid())
+        self.assertIn("Cannot change TimeAllocation", taf.non_field_errors()[0])
+
+    def test_clean_time_allocation_instrument_type_change_fails(self):
+        ta_dict = self.time_allocation.as_dict()
+        ta_dict['instrument_type'] = '2M0-FLOYDS-SCICAM'
+        taf = TimeAllocationForm(data=ta_dict, instance=self.time_allocation)
+        self.assertFalse(taf.is_valid())
+        self.assertIn("Cannot change TimeAllocation", taf.non_field_errors()[0])

--- a/observation_portal/proposals/tests.py
+++ b/observation_portal/proposals/tests.py
@@ -10,6 +10,7 @@ from django_dramatiq.test import DramatiqTestCase
 
 from observation_portal.proposals.models import ProposalInvite, Proposal, Membership, ProposalNotification, TimeAllocation, Semester
 from observation_portal.requestgroups.models import RequestGroup, Configuration, InstrumentConfig, Window
+from observation_portal.requestgroups import duration_utils
 from observation_portal.accounts.models import Profile
 from observation_portal.common.test_helpers import create_simple_requestgroup
 from observation_portal.proposals.tasks import time_allocation_reminder
@@ -317,8 +318,9 @@ class TestProposalAdmin(TestCase):
         self.assertTrue(taf.is_valid())
 
         # Now attempt to change the semester and see it fail
-        # ta_dict2 = self.time_allocation.as_dict()
-        # ta_dict2['semester'] = self.future_semester.id
-        # taf2 = TimeAllocationForm(data=ta_dict2, instance=self.time_allocation)
-        # self.assertFalse(taf2.is_valid())
-        # self.assertIn("Cannot change TimeAllocation", taf2.non_field_errors()[0])
+        ta_dict2 = self.time_allocation.as_dict()
+        ta_dict2['semester'] = self.future_semester.id
+        taf2 = TimeAllocationForm(data=ta_dict2, instance=self.time_allocation)
+        self.assertFalse(taf2.is_valid())
+        self.assertIn("Cannot change TimeAllocation", taf2.non_field_errors()[0])
+        duration_utils.semesters = None  # Clear the global semester variable that seems to be bad after this test

--- a/observation_portal/requestgroups/duration_utils.py
+++ b/observation_portal/requestgroups/duration_utils.py
@@ -2,6 +2,7 @@ from django.utils.translation import ugettext as _
 from math import ceil, floor
 from django.utils import timezone
 from django.conf import settings
+from django.core.cache import caches
 import logging
 
 from observation_portal.proposals.models import TimeAllocationKey, Proposal, Semester
@@ -13,13 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 PER_CONFIGURATION_STARTUP_TIME = 16.0   # per-configuration startup time, which encompasses initial pointing
-semesters = None
 
 
 def get_semesters():
-    global semesters
+    semesters = caches['locmem'].get('semesters')
     if not semesters:
         semesters = list(Semester.objects.all().order_by('-start'))
+        caches['locmem'].set('semesters', semesters, 60)
     return semesters
 
 


### PR DESCRIPTION
Either the line at the end of the unit test (nulling out the global semesters), or the change from a global variable to using the locmem cache will fix this. Which do you prefer? I can't remember why exactly we made this a global variable instead of something from the cache in the first place, but to me it seems like local memory cache would work best. I think this was an optimization to "cache" the semesters during each instance of processing a request, because we would query them many times through the course of validating a request I think... So a locmem cache should work just as well in that case.