### PR TITLE
Link the sciapp detail url setting from the admin page

### DIFF
--- a/observation_portal/sciapplications/admin.py
+++ b/observation_portal/sciapplications/admin.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.contrib import admin
-from django.utils.html import format_html
+from django.utils.html import format_html_join
 from django.urls import reverse
-
+from django.conf import settings
 
 from .models import (
     Instrument, Call, ScienceApplication, TimeRequest, CoInvestigator,
@@ -54,9 +54,14 @@ class ScienceApplicationAdmin(admin.ModelAdmin):
     search_fields = ['title', 'abstract', 'submitter__first_name', 'submitter__last_name', 'submitter__username']
 
     def preview_link(self, obj):
-        return format_html(
-            '<a href="{}">View on site</a>',
-            reverse('api:scienceapplications-detail', kwargs={'pk': obj.id})
+        urls = [{'text': 'View in API', 'url': reverse('api:scienceapplications-detail', args=(obj.id,))}]
+        if settings.SCIENCE_APPLICATION_DETAIL_URL:
+            urls.append(
+                {'text': 'View on site', 'url': settings.SCIENCE_APPLICATION_DETAIL_URL.format(sciapp_id=obj.id)}
+            )
+        return format_html_join(
+            ' ', '<a href="{}">{}</a>',
+            ((url['url'], url['text']) for url in urls)
         )
 
     def accept(self, request, queryset):

--- a/observation_portal/sciapplications/models.py
+++ b/observation_portal/sciapplications/models.py
@@ -163,7 +163,10 @@ class ScienceApplication(models.Model):
         return time_by_telescope_name
 
     def get_absolute_url(self):
-        return reverse('api:scienceapplications-detail', args=(self.id,))
+        if settings.SCIENCE_APPLICATION_DETAIL_URL:
+            return settings.SCIENCE_APPLICATION_DETAIL_URL.format(sciapp_id=self.id)
+        else:
+            return reverse('api:scienceapplications-detail', args=(self.id,))
 
     def convert_to_proposal(self):
         approved_time_requests = self.timerequest_set.filter(approved=True)

--- a/observation_portal/sciapplications/test_admin.py
+++ b/observation_portal/sciapplications/test_admin.py
@@ -1,8 +1,9 @@
+from datetime import timedelta
+
 from django.core import mail
 from django.urls import reverse
 from django.contrib.auth.models import User
 from django.utils import timezone
-from datetime import timedelta
 from mixer.backend.django import mixer
 from django_dramatiq.test import DramatiqTestCase
 
@@ -211,3 +212,19 @@ class TestSciAppAdmin(DramatiqTestCase):
         self.assertContains(response, 'A proposal named LCO{}-000 already exists.'.format(self.semester))
         # One application out of the bunch was successfully ported, so only one email was sent
         self.assertEqual(len(mail.outbox), 1)
+
+    def test_preview_link_only_api_link(self):
+        with self.settings(SCIENCE_APPLICATION_DETAIL_URL=''):
+            response = self.client.get(
+                reverse('admin:sciapplications_scienceapplication_changelist')
+            )
+            self.assertContains(response, 'View in API')
+            self.assertNotContains(response, 'View on Site')
+
+    def test_preview_link_on_site_link_included(self):
+        with self.settings(SCIENCE_APPLICATION_DETAIL_URL='http://localhost'):
+            response = self.client.get(
+                reverse('admin:sciapplications_scienceapplication_changelist')
+            )
+            self.assertContains(response, 'View in API')
+            self.assertContains(response, 'View on site')


### PR DESCRIPTION
These changes to the links are to make proposal management easier.
- The preview link column in the sciapplications list page on the admin site now optionally includes a link to the value of the `SCIENCE_APPLICATION_DETAIL_URL` setting if it is set.
- Also if the `SCIENCE_APPLICATION_DETAIL_URL` setting is set, use that url as the destination for the "View on Site" button on the change page of a sciapplication in the admin site.