### PR TITLE
change extra_params mixin to save integers and floats

### DIFF
--- a/observation_portal/common/mixins.py
+++ b/observation_portal/common/mixins.py
@@ -51,13 +51,17 @@ class CustomIsoDateTimeFilterMixin(object):
 
 class ExtraParamsFormatter(object):
     """ This should be mixed in with Serializers that have extra_params JSON fields, to ensure the float values are
-        stored as float values in the db instead of as strings
+        stored as float or integer values in the db instead of as strings
     """
     def to_internal_value(self, data):
         data = super().to_internal_value(data)
         for field, value in data.get('extra_params', {}).items():
             try:
-                data['extra_params'][field] = float(value)
+                float_value = float(value)
+                if float_value.is_integer():
+                    data['extra_params'][field] = int(float_value)
+                else:
+                    data['extra_params'][field] = float_value
             except (ValueError, TypeError):
                 pass
         return data


### PR DESCRIPTION
This was tripping up the cerberus validation of bin_x/bin_y in the extra params, since those were integer values but getting converted to floats due to this mixin, which then failed validation. Since we don't know the real intended type for any extra_param, I think it makes the most sense to store it as an integer if it is one, or a float if its a float. This way users can check against either type in their cerberus validation schema.