### PR TITLE
Add configuration types to instruments API response

### DIFF
--- a/observation_portal/requestgroups/views.py
+++ b/observation_portal/requestgroups/views.py
@@ -125,7 +125,8 @@ class InstrumentsInformationView(APIView):
                     'name': configdb.get_instrument_type_full_name(instrument_type),
                     'optical_elements': configdb.get_optical_elements(instrument_type),
                     'modes': configdb.get_modes_by_type(instrument_type),
-                    'default_acceptability_threshold': configdb.get_default_acceptability_threshold(instrument_type)
+                    'default_acceptability_threshold': configdb.get_default_acceptability_threshold(instrument_type),
+                    'configuration_types': configdb.get_configuration_types(instrument_type)
                 }
         return Response(info)
 


### PR DESCRIPTION
This information is used by the compose page to generate UI elements.