### PR TITLE
changes to fix rotation and centering in grid/line expansion

### DIFF
--- a/observation_portal/requestgroups/dither.py
+++ b/observation_portal/requestgroups/dither.py
@@ -54,7 +54,7 @@ def calc_line_offsets(num_points, point_spacing, orient, center):
     for i in range(0, max(num_points, 0)):
         distance = i*point_spacing + distance_offset
         # Angles measured clockwise from North ("y-axis") rather than anti-clockwise
-        # from East ("x-axis") so sin/cos flipped compared to normal
+        # from East ("x-axis")
         x_offset = (distance * -sino)
         y_offset = (distance * coso)
         offsets.append((x_offset, y_offset))
@@ -84,32 +84,32 @@ def calc_spiral_offsets(num_points, point_spacing):
 def calc_grid_offsets(num_rows, num_columns, point_spacing, line_spacing, orient=90, center=False):
     """Calculates offsets for a grid of <num_points> (must be a square number
     if scalar or a tuple of (n_columns x n_rows) grid points) with <point_spacing>
-    arcseconds apart horizontally and <line_spacing> arcseconds apart vertically,
-    orientated with columns increasing along <orient> degrees East of North
+    arcseconds apart vertically and <line_spacing> arcseconds apart horizontally at 0 orientation,
+    orientated with rows increasing along <orient> degrees East of North
     (clockwise from North through East)
     """
     offsets = []
 
     # A centered grid pattern has the middle of the grid corresponding with an offset of 0
-    row_distance_offset = -(line_spacing * (num_rows-1)) / 2.0 if center else 0.0
-    col_distance_offset = -(point_spacing * (num_columns-1)) / 2.0 if center else 0.0
+    row_distance_offset = -(point_spacing * (num_rows-1)) / 2.0 if center else 0.0
+    col_distance_offset = -(line_spacing * (num_columns-1)) / 2.0 if center else 0.0
     sino = sin(radians(orient))
     coso = cos(radians(orient))
-    rotated_x_offset = coso * col_distance_offset + sino * row_distance_offset
-    rotated_y_offset = -sino * col_distance_offset + coso * row_distance_offset
+    rotated_x_offset = coso * col_distance_offset - sino * row_distance_offset
+    rotated_y_offset = sino * col_distance_offset + coso * row_distance_offset
 
-    for row in range(0, num_rows):
-        if (row % 2) == 0:
-            columns = range(0, num_columns)
+    for column in range(0, num_columns):
+        if (column % 2) == 0:
+            rows = range(0, num_rows)
         else:
-            columns = reversed(range(0, num_columns))
-        for column in columns:
+            rows = reversed(range(0, num_rows))
+        for row in rows:
             # Angles measured clockwise from North ("y-axis") rather than anti-clockwise
-            # from East ("x-axis") so sin/cos flipped compared to normal
-            base_x = column * point_spacing
-            base_y = row * line_spacing
-            x_offset = base_x * coso + base_y * sino + rotated_x_offset
-            y_offset = base_x * -sino + base_y * coso + rotated_y_offset
+            # from East ("x-axis")
+            base_x = column * line_spacing
+            base_y = row * point_spacing
+            x_offset = base_x * coso + base_y * -sino + rotated_x_offset
+            y_offset = base_x * sino + base_y * coso + rotated_y_offset
             offsets.append((x_offset, y_offset))
 
     return offsets

--- a/observation_portal/requestgroups/dither.py
+++ b/observation_portal/requestgroups/dither.py
@@ -12,8 +12,8 @@ def expand_dither_pattern(dither_details):
     '''
     configuration_dict = dither_details.get('configuration', {})
     offsets = []
-    instrument_configs = []
-    instrument_config = configuration_dict.get('instrument_configs', [{}])[0]
+    final_instrument_configs = []
+    instrument_configs = configuration_dict.get('instrument_configs', [])
     pattern = dither_details.get('pattern')
     if pattern == 'line':
         offsets = calc_line_offsets(dither_details.get('num_points'), dither_details.get('point_spacing'), dither_details.get('orientation'),
@@ -26,14 +26,15 @@ def expand_dither_pattern(dither_details):
 
 
     for offset in offsets:
-        instrument_config_copy = deepcopy(instrument_config)
-        if 'extra_params' not in instrument_config_copy:
-            instrument_config_copy['extra_params'] = {}
-        instrument_config_copy['extra_params']['offset_ra'] = round(offset[0], 3)
-        instrument_config_copy['extra_params']['offset_dec'] = round(offset[1], 3)
-        instrument_configs.append(instrument_config_copy)
+        for instrument_config in instrument_configs:
+            instrument_config_copy = deepcopy(instrument_config)
+            if 'extra_params' not in instrument_config_copy:
+                instrument_config_copy['extra_params'] = {}
+            instrument_config_copy['extra_params']['offset_ra'] = round(offset[0], 3)
+            instrument_config_copy['extra_params']['offset_dec'] = round(offset[1], 3)
+            final_instrument_configs.append(instrument_config_copy)
 
-    configuration_dict['instrument_configs'] = instrument_configs
+    configuration_dict['instrument_configs'] = final_instrument_configs
     return configuration_dict
 
 

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -860,12 +860,6 @@ class DitherSerializer(serializers.Serializer):
     num_columns = serializers.IntegerField(required=False)
     center = serializers.BooleanField(required=False, default=False)
 
-    def validate_configuration(self, configuration):
-        if len(configuration.get('instrument_configs', [])) > 1:
-            raise serializers.ValidationError(_("Cannot expand a configuration for dithering with more than one instrument_config set"))
-
-        return configuration
-
     def validate(self, data):
         validated_data = super().validate(data)
         if 'num_points' not in validated_data and validated_data.get('pattern') in ['line', 'spiral']:

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -913,10 +913,10 @@ class TestDitherApi(SetTimeMixin, APITestCase):
         response = self.client.post(reverse('api:configuration-dither'), data=dither_data)
         self.assertEqual(response.status_code, 200)
         config_dict = response.json()
-        offset_diff_dec = config_dict['instrument_configs'][3]['extra_params']['offset_dec'] - config_dict['instrument_configs'][0]['extra_params']['offset_dec']
-        offset_diff_ra = config_dict['instrument_configs'][1]['extra_params']['offset_ra'] - config_dict['instrument_configs'][0]['extra_params']['offset_ra']
+        offset_diff_dec = config_dict['instrument_configs'][2]['extra_params']['offset_dec'] - config_dict['instrument_configs'][0]['extra_params']['offset_dec']
+        offset_diff_ra = config_dict['instrument_configs'][2]['extra_params']['offset_ra'] - config_dict['instrument_configs'][0]['extra_params']['offset_ra']
         self.assertEqual(offset_diff_ra, dither_data['point_spacing'])
-        self.assertEqual(offset_diff_dec, dither_data['point_spacing'])
+        self.assertEqual(offset_diff_dec, -dither_data['point_spacing'])
 
 
 class TestCadenceApi(SetTimeMixin, APITestCase):

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -922,10 +922,10 @@ class TestDitherApi(SetTimeMixin, APITestCase):
         response = self.client.post(reverse('api:configuration-dither'), data=dither_data)
         self.assertEqual(response.status_code, 200)
         config_dict = response.json()
-        offset_diff_dec = config_dict['instrument_configs'][2]['extra_params']['offset_dec'] - config_dict['instrument_configs'][0]['extra_params']['offset_dec']
-        offset_diff_ra = config_dict['instrument_configs'][2]['extra_params']['offset_ra'] - config_dict['instrument_configs'][0]['extra_params']['offset_ra']
+        offset_diff_dec = abs(config_dict['instrument_configs'][2]['extra_params']['offset_dec'] - config_dict['instrument_configs'][0]['extra_params']['offset_dec'])
+        offset_diff_ra = abs(config_dict['instrument_configs'][2]['extra_params']['offset_ra'] - config_dict['instrument_configs'][0]['extra_params']['offset_ra'])
         self.assertEqual(offset_diff_ra, dither_data['point_spacing'])
-        self.assertEqual(offset_diff_dec, -dither_data['point_spacing'])
+        self.assertEqual(offset_diff_dec, dither_data['point_spacing'])
 
 
 class TestCadenceApi(SetTimeMixin, APITestCase):


### PR DESCRIPTION
Okay try two! I found that the grid was wonky even without the rotation (try setting centering on a non-square grid to see), so I ended up rewriting the equations for the grid entirely. Both rotation and centering should now work with the grid, and the rotation is in the direction we say it should be, which is non-standard but is what Tim had in his comments so I'm sticking with it. The grid may look different then it did before, but that shouldn't matter since we can define it however we want - the grid will now go in +dec and -ra by default, but can be +dec and +ra if rotated 90 degrees and using num_rows/columns opposite.

I also fixed the rotation in the line to be in the same direction as the grid, which is clockwise from north (+y-axis) towards east (+x-axis).