### PR TITLE
Fix/ task scheduler error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     use_scm_version=True,
     setup_requires=['setuptools_scm', 'wheel', 'numpy>=1.16,<1.17'],
     install_requires=[
-        'apscheduler>=3.6,<3.7',
+        'apscheduler>=3.7,<3.8',
         'boto3<2.0',
         'cerberus>1.0,<2.0',
         'django>=2.2,<2.3',


### PR DESCRIPTION
The dramatiq scheduler was erroring out on startup with:
```
...
  File "/usr/local/lib/python3.7/site-packages/observation_portal/task_scheduler.py", line 28, in run                                                                                        [56/47831]
    scheduler.start()                                                                                                                                                                                  
  File "/usr/local/lib/python3.7/site-packages/apscheduler/schedulers/blocking.py", line 18, in start                                                                                                  
    super(BlockingScheduler, self).start(*args, **kwargs)                                                                                                                                              
  File "/usr/local/lib/python3.7/site-packages/apscheduler/schedulers/base.py", line 162, in start                                                                                                     
    self._real_add_job(job, jobstore_alias, replace_existing)                                                                                                                                          
  File "/usr/local/lib/python3.7/site-packages/apscheduler/schedulers/base.py", line 859, in _real_add_job                                                                                             
    replacements['next_run_time'] = job.trigger.get_next_fire_time(None, now)                                                                                                                          
  File "/usr/local/lib/python3.7/site-packages/apscheduler/triggers/cron/__init__.py", line 182, in get_next_fire_time                                                                                 
    next_date = self._set_field_value(next_date, fieldnum, next_value)                                                                                                                                 
  File "/usr/local/lib/python3.7/site-packages/apscheduler/triggers/cron/__init__.py", line 159, in _set_field_value                                                                                   
    return self.timezone.localize(datetime(**values))                                                                                                                                                  
AttributeError: 'backports.zoneinfo.ZoneInfo' object has no attribute 'localize'
```
I found a recently opened `apscheduler` issue with the same exact error, where the fix was to use at least version 3.7 of that library: https://github.com/agronholm/apscheduler/issues/537