### PR TITLE
Add preemption_enabled flag to cancel endpoint to allow cancelling of…

### DIFF
--- a/observation_portal/observations/serializers.py
+++ b/observation_portal/observations/serializers.py
@@ -401,6 +401,7 @@ class CancelObservationsSerializer(serializers.Serializer):
     include_normal = serializers.BooleanField(required=False, default=True)
     include_rr = serializers.BooleanField(required=False, default=False)
     include_direct = serializers.BooleanField(required=False, default=False)
+    preemption_enabled = serializers.BooleanField(required=False, default=False)
 
     def validate(self, data):
         if 'ids' not in data and ('start' not in data or 'end' not in data):


### PR DESCRIPTION
… in_progress observations. I ended up leaving the logic mostly as is, except for separating the by id and by time-range, and exiting out of the cancel call early with a 400 if it will cancel an overlapping in_progress observation and doesn't have preemption_enabled flag set to True.