### PR TITLE
Maintain consistent use of timezone-aware datetimes

### DIFF
--- a/observation_portal/observations/tasks.py
+++ b/observation_portal/observations/tasks.py
@@ -1,7 +1,7 @@
 import dramatiq
 import logging
-from datetime import datetime, timedelta
-from django.utils.timezone import make_aware
+from datetime import timedelta
+from django.utils import timezone
 
 from observation_portal.observations.models import Observation
 
@@ -10,6 +10,6 @@ logger = logging.getLogger(__name__)
 
 @dramatiq.actor()
 def delete_old_observations():
-    cutoff = make_aware(datetime.utcnow() - timedelta(days=14))
+    cutoff = timezone.now() - timedelta(days=14)
     logger.info(f'Deleting CANCELED observations before cutoff date {cutoff}')
     Observation.delete_old_observations(cutoff)

--- a/observation_portal/observations/tasks.py
+++ b/observation_portal/observations/tasks.py
@@ -1,6 +1,7 @@
 import dramatiq
 import logging
 from datetime import datetime, timedelta
+from django.utils.timezone import make_aware
 
 from observation_portal.observations.models import Observation
 
@@ -9,6 +10,6 @@ logger = logging.getLogger(__name__)
 
 @dramatiq.actor()
 def delete_old_observations():
-    cutoff = datetime.utcnow() - timedelta(days=14)
+    cutoff = make_aware(datetime.utcnow() - timedelta(days=14))
     logger.info(f'Deleting CANCELED observations before cutoff date {cutoff}')
     Observation.delete_old_observations(cutoff)


### PR DESCRIPTION
This fixes a runtime warning caused by mixing datetime objects with and without timezone awareness. Found while integrating dramatiq in the ocs_example project (while running the task `delete_old_observations`):

`dramatiq_worker_1          | /usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1427: RuntimeWarning: DateTimeField Observation.end received a naive datetime (2021-08-19 20:00:00.496106) while time zone support is active.`

The `make_aware` function will use the timezone defined in `settings.TIME_ZONE`, which is currently UTC.

The task worked fine despite the warning, so this inclusion won't change program behavior. 

See https://stackoverflow.com/a/45080605/5063889