### PR TITLE
Added tests and fixed up the authentication integration

### DIFF
--- a/observation_portal/accounts/apps.py
+++ b/observation_portal/accounts/apps.py
@@ -3,3 +3,7 @@ from django.apps import AppConfig
 
 class AccountsConfig(AppConfig):
     name = 'observation_portal.accounts'
+
+    def ready(self):
+        import observation_portal.accounts.signals.handlers  # noqa
+        super().ready()

--- a/observation_portal/accounts/management/commands/create_user.py
+++ b/observation_portal/accounts/management/commands/create_user.py
@@ -34,10 +34,11 @@ class Command(BaseCommand):
         except IntegrityError:
             user = User.objects.get(username=options['user'])
             logging.warning(f"user {options['user']} already exists")
-        Profile.objects.get_or_create(user=user)
 
         token, _ = Token.objects.get_or_create(user=user)
         if options['token']:
             # Need to set the api token to some expected value
             token.delete()
             Token.objects.create(user=user, key=options['token'])
+
+        Profile.objects.get_or_create(user=user)

--- a/observation_portal/accounts/management/commands/updateclientusers.py
+++ b/observation_portal/accounts/management/commands/updateclientusers.py
@@ -1,0 +1,36 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.utils.module_loading import import_string
+from urllib.parse import urljoin
+import requests
+import json
+
+import sys
+import logging
+
+logger = logging.getLogger()
+
+
+class Command(BaseCommand):
+    help = 'Sync user accounts between client applications.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('-u', '--client-url', dest='client_url', type=str,
+                            help='client url to call the /addupdateuser on for each user')
+
+    def handle(self, *args, **options):
+        logger.info(f"Updating client user details for {options['client_url']}")
+        url = urljoin(options['client_url'], '/authprofile/addupdateuser/')
+        header = {'Authorization': f"Server {settings.OAUTH_SERVER_KEY}"}
+        users = User.objects.all()
+        for user in users:
+            try:
+                data = import_string(settings.SERIALIZERS['accounts']['User'])(user).data
+                response = requests.post(url, data=json.dumps(data), headers=header)
+                response.raise_for_status()
+            except Exception as e:
+                logger.error(f"Failed to update client user details, please run this command again", exc_info=1)
+                sys.exit(1)
+        
+        logger.info("Finished updating client user details.")

--- a/observation_portal/accounts/management/commands/updateclientusers.py
+++ b/observation_portal/accounts/management/commands/updateclientusers.py
@@ -29,8 +29,8 @@ class Command(BaseCommand):
                 data = import_string(settings.SERIALIZERS['accounts']['User'])(user).data
                 response = requests.post(url, data=json.dumps(data), headers=header)
                 response.raise_for_status()
-            except Exception as e:
-                logger.error(f"Failed to update client user details, please run this command again", exc_info=1)
+            except Exception:
+                logger.error("Failed to update client user details, please run this command again", exc_info=1)
                 sys.exit(1)
-        
+
         logger.info("Finished updating client user details.")

--- a/observation_portal/accounts/models.py
+++ b/observation_portal/accounts/models.py
@@ -39,25 +39,6 @@ class Profile(models.Model):
             )
         )
 
-    @property
-    def archive_bearer_token(self):
-        # During testing, you will probably have to copy access tokens from prod for this to work
-        try:
-            app = Application.objects.get(name='Archive')
-        except Application.DoesNotExist:
-            logger.error('Archive application not found. Oauth applications need to be populated.')
-            return ''
-        access_token = AccessToken.objects.filter(user=self.user, application=app, expires__gt=timezone.now()).last()
-        if not access_token:
-            access_token = AccessToken(
-                user=self.user,
-                application=app,
-                token=uuid.uuid4().hex,
-                expires=timezone.now() + timedelta(days=30)
-            )
-            access_token.save()
-        return access_token.token
-
     @cached_property
     def current_proposals(self):
         return Proposal.current_proposals().filter(active=True, membership__user=self.user).distinct()

--- a/observation_portal/accounts/serializers.py
+++ b/observation_portal/accounts/serializers.py
@@ -68,6 +68,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     def get_tokens(self, obj):
         return {
+            'archive': obj.profile.archive_bearer_token,
             'api_token': obj.profile.api_token.key
         }
 

--- a/observation_portal/accounts/serializers.py
+++ b/observation_portal/accounts/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from django.contrib.auth.models import User
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.module_loading import import_string
 from django.conf import settings
 
@@ -44,7 +44,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = (
-            'username', 'first_name', 'last_name', 'email', 'profile', 'is_staff', 'proposals',
+            'username', 'first_name', 'last_name', 'email', 'profile', 'is_staff', 'is_superuser', 'proposals',
             'available_instrument_types', 'tokens', 'proposal_notifications'
         )
 
@@ -68,7 +68,6 @@ class UserSerializer(serializers.ModelSerializer):
 
     def get_tokens(self, obj):
         return {
-            'archive': obj.profile.archive_bearer_token,
             'api_token': obj.profile.api_token.key
         }
 
@@ -78,8 +77,7 @@ class UserSerializer(serializers.ModelSerializer):
         return data
 
     def update(self, instance, validated_data):
-        user_update_fields = ['email', 'username', 'last_name', 'first_name']
-        instance.username = validated_data.get('username', instance.username)
+        user_update_fields = ['email', 'last_name', 'first_name']
         instance.email = validated_data.get('email', instance.email)
         instance.last_name = validated_data.get('last_name', instance.last_name)
         instance.first_name = validated_data.get('first_name', instance.first_name)

--- a/observation_portal/accounts/signals/handlers.py
+++ b/observation_portal/accounts/signals/handlers.py
@@ -1,0 +1,25 @@
+import json
+from django.dispatch import receiver
+from django.db.models.signals import post_save
+from django.contrib.auth.models import User
+from django.utils.module_loading import import_string
+from django.conf import settings
+
+from observation_portal.accounts.tasks import update_or_create_client_applications_user
+from observation_portal.accounts.models import Profile
+
+
+@receiver(post_save, sender=User)
+def cb_user_post_save(sender, instance, created, *args, **kwargs):
+    # Only update the user if it was not just created. If it was just created, we must wait until
+    # the Profile is created to send the update since we need profile information, which should happen
+    # immediately after user creation in our registration system.
+    if not created and not (kwargs.get('update_fields') == frozenset({'last_login'})):
+        user_json = json.dumps(import_string(settings.SERIALIZERS['accounts']['User'])(instance).data)
+        update_or_create_client_applications_user.send(user_json)
+
+
+@receiver(post_save, sender=Profile)
+def cb_profile_post_save(sender, instance, created, *args, **kwargs):
+    user_json = json.dumps(import_string(settings.SERIALIZERS['accounts']['User'])(instance.user).data)
+    update_or_create_client_applications_user.send(user_json)

--- a/observation_portal/accounts/tasks.py
+++ b/observation_portal/accounts/tasks.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from oauth2_provider.models import AccessToken
 from urllib.parse import urljoin
 import logging
-import json
 import requests
 
 
@@ -22,7 +21,7 @@ def update_or_create_client_applications_user(user_json):
     """
     for base_url in settings.OAUTH_CLIENT_APPS_BASE_URLS:
         url = urljoin(base_url, '/authprofile/addupdateuser/')
-        logger.warning(f"Updating user details at {url}")
+        logger.info(f"Updating user details at {url}")
         header = {'Authorization': f"Server {settings.OAUTH_SERVER_KEY}"}
         response = requests.post(url, data=user_json, headers=header)
         response.raise_for_status()

--- a/observation_portal/accounts/test_utils.py
+++ b/observation_portal/accounts/test_utils.py
@@ -1,6 +1,5 @@
 from mixer.backend.django import mixer
 from django.utils import timezone
-from django.db.models import signals
 from django.db.models.signals import post_save
 
 from observation_portal.accounts.models import User, Profile

--- a/observation_portal/accounts/test_utils.py
+++ b/observation_portal/accounts/test_utils.py
@@ -1,18 +1,25 @@
 from mixer.backend.django import mixer
 from django.utils import timezone
+from django.db.models import signals
+from django.db.models.signals import post_save
 
 from observation_portal.accounts.models import User, Profile
+from observation_portal.common.test_helpers import disconnect_signal
+from observation_portal.accounts.signals.handlers import cb_user_post_save, cb_profile_post_save
 
 
 def blend_user(user_params=None, profile_params=None):
-    if user_params:
-        user = mixer.blend(User, **user_params)
-    else:
-        user = mixer.blend(User, is_staff=False, is_superuser=False)
+    with disconnect_signal(post_save, cb_user_post_save, User):
+        with disconnect_signal(post_save, cb_profile_post_save, Profile):
 
-    if profile_params:
-        mixer.blend(Profile, user=user, terms_accepted=timezone.now(), **profile_params)
-    else:
-        mixer.blend(Profile, user=user, terms_accepted=timezone.now())
+            if user_params:
+                user = mixer.blend(User, **user_params)
+            else:
+                user = mixer.blend(User, is_staff=False, is_superuser=False)
 
-    return user
+            if profile_params:
+                mixer.blend(Profile, user=user, terms_accepted=timezone.now(), **profile_params)
+            else:
+                mixer.blend(Profile, user=user, terms_accepted=timezone.now())
+
+            return user

--- a/observation_portal/accounts/tests.py
+++ b/observation_portal/accounts/tests.py
@@ -10,7 +10,6 @@ from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.urls import reverse
 from mixer.backend.django import mixer
-from oauth2_provider.models import Application, AccessToken
 from rest_framework.authtoken.models import Token
 from django.core import mail
 from django_dramatiq.test import DramatiqTestCase

--- a/observation_portal/accounts/tests.py
+++ b/observation_portal/accounts/tests.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 import copy
+import responses
 
 from django.test import TestCase
 from rest_framework.test import APITestCase
@@ -19,42 +20,10 @@ from observation_portal.accounts.models import Profile
 from observation_portal.proposals.models import Proposal, Membership, TimeAllocation
 
 
-class TestArchiveBearerToken(TestCase):
-    def setUp(self):
-        self.profile = mixer.blend(Profile)
-
-    def test_no_archive_app(self):
-        self.assertEqual(self.profile.archive_bearer_token, '')
-
-    def test_new_token(self):
-        mixer.blend(Application, name='Archive')
-        self.assertTrue(self.profile.archive_bearer_token)
-
-    def test_existing_token(self):
-        app = mixer.blend(Application, name='Archive')
-        at = mixer.blend(
-            AccessToken,
-            application=app,
-            user=self.profile.user,
-            expires=timezone.now() + timedelta(days=30)
-        )
-        self.assertEqual(self.profile.archive_bearer_token, at.token)
-
-    def test_expired_token(self):
-        app = mixer.blend(Application, name='Archive')
-        at = mixer.blend(
-            AccessToken,
-            application=app,
-            user=self.profile.user,
-            expires=timezone.now() - timedelta(days=1)
-        )
-        self.assertNotEqual(self.profile.archive_bearer_token, at.token)
-
-
 class TestAPIQuota(TestCase):
     def setUp(self):
-        user = mixer.blend(User)
-        self.profile = mixer.blend(Profile, user=user)
+        user = blend_user()
+        self.profile = user.profile
 
     def test_quota_is_zero(self):
         self.assertEqual(self.profile.api_quota['used'], 0)
@@ -234,7 +203,7 @@ class TestProfileAPI(APITestCase):
 
     def test_unique_email(self):
         duplicate_email = 'first@example.com'
-        mixer.blend(User, email=duplicate_email)
+        blend_user(user_params={'email': duplicate_email})
         bad_data = copy.deepcopy(self.data)
         bad_data['email'] = duplicate_email
         response = self.client.patch(reverse('api:profile'), data=bad_data)
@@ -270,3 +239,67 @@ class TestProfileAPI(APITestCase):
             Token.objects.get(user=self.user)
         self.client.get(reverse('api:profile'))
         self.assertTrue(Token.objects.get(user=self.user))
+
+
+class TestClientUserUpdates(DramatiqTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = blend_user()
+        self.api_token = self.user.profile.api_token.key  # This triggers creating the api_token if it doesn't exist
+        self.profile = self.user.profile
+        self.client.force_login(self.user)
+
+    def test_user_update_triggers_client_user_update(self):
+        with self.settings(OAUTH_CLIENT_APPS_BASE_URLS=['http://test1.lco.global', 'http://test2.lco.global']):
+            responses.add(responses.POST, 'http://test1.lco.global/authprofile/addupdateuser/',
+                    json={'message': 'User account updated'}, status=200)
+
+            responses.add(responses.POST, 'http://test2.lco.global/authprofile/addupdateuser/',
+                    json={'message': 'User account updated'}, status=200)
+
+            self.user.is_staff = not self.user.is_staff
+            self.user.save()
+
+            self.broker.join('default')
+            self.worker.join()
+
+            self.assertGreaterEqual(len(responses.calls), 2)
+            self.assertEqual(responses.calls[-2].request.url, 'http://test1.lco.global/authprofile/addupdateuser/')
+            self.assertEqual(responses.calls[-2].response.text, '{"message": "User account updated"}')
+            self.assertEqual(responses.calls[-1].request.url, 'http://test2.lco.global/authprofile/addupdateuser/')
+            self.assertEqual(responses.calls[-1].response.text, '{"message": "User account updated"}')
+
+    def test_profile_update_triggers_client_user_update(self):
+        with self.settings(OAUTH_CLIENT_APPS_BASE_URLS=['http://test1.lco.global', 'http://test2.lco.global']):
+            responses.add(responses.POST, 'http://test1.lco.global/authprofile/addupdateuser/',
+                    json={'message': 'User account updated'}, status=200)
+
+            responses.add(responses.POST, 'http://test2.lco.global/authprofile/addupdateuser/',
+                    json={'message': 'User account updated'}, status=200)
+
+            self.profile.staff_view = not self.profile.staff_view
+            self.profile.save()
+
+            self.broker.join('default')
+            self.worker.join()
+
+            self.assertGreaterEqual(len(responses.calls), 2)
+            self.assertEqual(responses.calls[-2].request.url, 'http://test1.lco.global/authprofile/addupdateuser/')
+            self.assertEqual(responses.calls[-2].response.text, '{"message": "User account updated"}')
+            self.assertEqual(responses.calls[-1].request.url, 'http://test2.lco.global/authprofile/addupdateuser/')
+            self.assertEqual(responses.calls[-1].response.text, '{"message": "User account updated"}')
+
+    def test_revoking_token_triggers_client_user_update(self):
+        with self.settings(OAUTH_CLIENT_APPS_BASE_URLS=['http://test1.lco.global']):
+            responses.add(responses.POST, 'http://test1.lco.global/authprofile/addupdateuser/',
+                    json={'message': 'User account updated'}, status=200)
+
+            response = self.client.post(reverse('api:revoke_api_token'))
+            self.assertContains(response, 'API token revoked', status_code=200)
+
+            self.broker.join('default')
+            self.worker.join()
+
+            self.assertGreaterEqual(len(responses.calls), 1)
+            self.assertEqual(responses.calls[-1].request.url, 'http://test1.lco.global/authprofile/addupdateuser/')
+            self.assertEqual(responses.calls[-1].response.text, '{"message": "User account updated"}')

--- a/observation_portal/accounts/views.py
+++ b/observation_portal/accounts/views.py
@@ -59,9 +59,8 @@ class RevokeApiTokenApiView(APIView):
 
     def post(self, request):
         """A simple POST request (empty request body) with user authentication information in the HTTP header will revoke a user's API Token."""
-        old_token = request.user.auth_token.key
         request.user.auth_token.delete()
-        new_token = Token.objects.create(user=request.user)
+        Token.objects.create(user=request.user)
         # The Oauth Client applications must have their api_token updated as well
         user_json = json.dumps(import_string(settings.SERIALIZERS['accounts']['User'])(request.user).data)
         update_or_create_client_applications_user.send(user_json)

--- a/observation_portal/common/configdb.py
+++ b/observation_portal/common/configdb.py
@@ -5,7 +5,7 @@ from math import sqrt
 
 import requests
 from django.core.cache import caches
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.conf import settings
 
 from observation_portal.common.utils import cache_function

--- a/observation_portal/common/downtimedb.py
+++ b/observation_portal/common/downtimedb.py
@@ -1,6 +1,6 @@
 import requests
 from django.core.cache import caches
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.conf import settings
 from django.utils import timezone
 import logging

--- a/observation_portal/common/state_changes.py
+++ b/observation_portal/common/state_changes.py
@@ -6,7 +6,7 @@ from django.core.cache import cache
 from django.db import transaction
 from django.db.models import F
 from django.utils import timezone
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from observation_portal.observations.models import Observation
 from observation_portal.proposals.models import TimeAllocation

--- a/observation_portal/common/test_state_changes.py
+++ b/observation_portal/common/test_state_changes.py
@@ -8,6 +8,7 @@ from django.db.models.signals import post_save
 from django.core import mail
 from django_dramatiq.test import DramatiqTestCase
 
+from observation_portal.accounts.test_utils import blend_user
 from observation_portal.observations.signals.handlers import cb_configurationstatus_post_save
 import observation_portal.observations.signals.handlers  # noqa
 import observation_portal.requestgroups.signals.handlers  # noqa
@@ -30,8 +31,7 @@ class TestStateChanges(SetTimeMixin, TestCase):
     def setUp(self):
         super().setUp()
         self.proposal = dmixer.blend(Proposal)
-        self.user = dmixer.blend(User)
-        dmixer.blend(Profile, user=self.user)
+        self.user = blend_user()
         self.client.force_login(self.user)
         now = timezone.now()
         # Create a requestgroup with 3 requests, each request has 3 configurations with current windows and observations
@@ -347,9 +347,8 @@ class TestStateFromConfigurationStatuses(SetTimeMixin, DramatiqTestCase):
     def setUp(self):
         super().setUp()
         self.proposal = dmixer.blend(Proposal)
-        self.user = dmixer.blend(User)
+        self.user = blend_user(profile_params={'notifications_enabled': True})
         dmixer.blend(Membership, user=self.user, proposal=self.proposal)
-        dmixer.blend(Profile, user=self.user, notifications_enabled=True)
         self.client.force_login(self.user)
         self.now = timezone.now()
         self.window = dmixer.blend(Window, start=self.now - timedelta(days=1), end=self.now + timedelta(days=1))
@@ -544,8 +543,7 @@ class TestRequestState(SetTimeMixin, TestCase):
     def setUp(self):
         super().setUp()
         self.proposal = dmixer.blend(Proposal)
-        self.user = dmixer.blend(User)
-        dmixer.blend(Profile, user=self.user)
+        self.user = blend_user()
         self.client.force_login(self.user)
         self.now = timezone.now()
         self.window = dmixer.blend(Window, start=self.now - timedelta(days=1), end=self.now + timedelta(days=1))

--- a/observation_portal/common/test_state_changes.py
+++ b/observation_portal/common/test_state_changes.py
@@ -3,7 +3,6 @@ from mixer.backend.django import mixer as dmixer
 from django.utils import timezone
 from datetime import timedelta
 from unittest.mock import patch
-from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.core import mail
 from django_dramatiq.test import DramatiqTestCase
@@ -17,7 +16,6 @@ from observation_portal.common.test_helpers import (
     disconnect_signal
 )
 from observation_portal.proposals.models import Proposal, Membership
-from observation_portal.accounts.models import Profile
 from observation_portal.observations.models import Observation, ConfigurationStatus, Summary
 from observation_portal.requestgroups.models import Request, RequestGroup, Window, Location
 from observation_portal.common.state_changes import (

--- a/observation_portal/observations/serializers.py
+++ b/observation_portal/observations/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from django.utils import timezone
 from django.core.cache import cache
 from django.db import transaction
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.module_loading import import_string
 from django.conf import settings
 

--- a/observation_portal/observations/test/tests.py
+++ b/observation_portal/observations/test/tests.py
@@ -4,7 +4,6 @@ from io import StringIO
 from rest_framework.test import APITestCase
 from django.utils import timezone
 from mixer.backend.django import mixer
-from django.contrib.auth.models import User
 from dateutil.parser import parse
 from django.urls import reverse
 from django.core.cache import caches
@@ -15,7 +14,6 @@ from observation_portal.requestgroups.models import RequestGroup, Window, Locati
 from observation_portal.observations.time_accounting import configuration_time_used
 from observation_portal.observations.models import Observation, ConfigurationStatus, Summary
 from observation_portal.proposals.models import Proposal, Membership, Semester, TimeAllocation
-from observation_portal.accounts.models import Profile
 from observation_portal.common.test_helpers import create_simple_requestgroup, create_simple_configuration
 from observation_portal.accounts.test_utils import blend_user
 from observation_portal.observations import views

--- a/observation_portal/observations/test/tests.py
+++ b/observation_portal/observations/test/tests.py
@@ -89,8 +89,7 @@ class TestPostScheduleApi(SetTimeMixin, APITestCase):
     def setUp(self):
         super().setUp()
         self.proposal = mixer.blend(Proposal, direct_submission=True)
-        self.user = mixer.blend(User, is_admin=True, is_superuser=True, is_staff=True)
-        mixer.blend(Profile, user=self.user)
+        self.user = blend_user(user_params={'is_admin': True, 'is_superuser': True, 'is_staff': True})
         self.client.force_login(self.user)
         self.semester = mixer.blend(
             Semester, id='2016B', start=datetime(2016, 9, 1, tzinfo=timezone.utc),
@@ -102,13 +101,13 @@ class TestPostScheduleApi(SetTimeMixin, APITestCase):
         self.observation['proposal'] = self.proposal.id
 
     def test_post_observation_user_not_logged_in(self):
-        other_user = mixer.blend(User)
+        other_user = blend_user()
         self.client.force_login(other_user)
         response = self.client.post(reverse('api:schedule-list'), data=self.observation)
         self.assertEqual(response.status_code, 403)
 
     def test_post_observation_user_not_on_proposal(self):
-        other_user = mixer.blend(User, is_staff=True)
+        other_user = blend_user(user_params={'is_staff': True})
         self.client.force_login(other_user)
         response = self.client.post(reverse('api:schedule-list'), data=self.observation)
         self.assertEqual(response.status_code, 400)
@@ -362,8 +361,7 @@ class TestPostScheduleMultiConfigApi(SetTimeMixin, APITestCase):
     def setUp(self):
         super().setUp()
         self.proposal = mixer.blend(Proposal, direct_submission=True)
-        self.user = mixer.blend(User, is_admin=True, is_superuser=True, is_staff=True)
-        mixer.blend(Profile, user=self.user)
+        self.user = blend_user(user_params={'is_admin': True, 'is_superuser': True, 'is_staff': True})
         self.client.force_login(self.user)
         self.semester = mixer.blend(
             Semester, id='2016B', start=datetime(2016, 9, 1, tzinfo=timezone.utc),
@@ -422,8 +420,7 @@ class TestObservationApiBase(SetTimeMixin, APITestCase):
     def setUp(self):
         super().setUp()
         self.proposal = mixer.blend(Proposal, direct_submission=False)
-        self.user = mixer.blend(User, is_admin=True, is_superuser=True, is_staff=True)
-        mixer.blend(Profile, user=self.user)
+        self.user = blend_user(user_params={'is_admin': True, 'is_superuser': True, 'is_staff': True})
         self.client.force_login(self.user)
         self.semester = mixer.blend(
             Semester, id='2016B', start=datetime(2016, 9, 1, tzinfo=timezone.utc),

--- a/observation_portal/proposals/models.py
+++ b/observation_portal/proposals/models.py
@@ -4,7 +4,7 @@ from django.utils.functional import cached_property
 from django.forms import model_to_dict
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.html import strip_tags

--- a/observation_portal/proposals/serializers.py
+++ b/observation_portal/proposals/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.module_loading import import_string
 from django.conf import settings
 

--- a/observation_portal/proposals/tests.py
+++ b/observation_portal/proposals/tests.py
@@ -11,7 +11,6 @@ from django_dramatiq.test import DramatiqTestCase
 from observation_portal.proposals.models import ProposalInvite, Proposal, Membership, ProposalNotification, TimeAllocation, Semester
 from observation_portal.requestgroups.models import RequestGroup, Configuration, InstrumentConfig, Window
 from observation_portal.accounts.test_utils import blend_user
-from observation_portal.accounts.models import Profile
 from observation_portal.common.test_helpers import create_simple_requestgroup
 from observation_portal.proposals.tasks import time_allocation_reminder
 from observation_portal.requestgroups.signals import handlers  # DO NOT DELETE, needed to active signals

--- a/observation_portal/proposals/tests.py
+++ b/observation_portal/proposals/tests.py
@@ -10,6 +10,7 @@ from django_dramatiq.test import DramatiqTestCase
 
 from observation_portal.proposals.models import ProposalInvite, Proposal, Membership, ProposalNotification, TimeAllocation, Semester
 from observation_portal.requestgroups.models import RequestGroup, Configuration, InstrumentConfig, Window
+from observation_portal.accounts.test_utils import blend_user
 from observation_portal.accounts.models import Profile
 from observation_portal.common.test_helpers import create_simple_requestgroup
 from observation_portal.proposals.tasks import time_allocation_reminder
@@ -20,7 +21,7 @@ from observation_portal.proposals.forms import TimeAllocationForm
 class TestProposal(DramatiqTestCase):
     def test_add_existing_user(self):
         proposal = mixer.blend(Proposal)
-        user = mixer.blend(User, email='email1@example.com')
+        user = blend_user(user_params={'email': 'email1@example.com'})
         emails = ['email1@example.com']
         proposal.add_users(emails, Membership.CI)
 
@@ -47,14 +48,14 @@ class TestProposal(DramatiqTestCase):
 
     def test_no_dual_membership(self):
         proposal = mixer.blend(Proposal)
-        user = mixer.blend(User)
+        user = blend_user()
         Membership.objects.create(user=user, proposal=proposal, role=Membership.PI)
         with self.assertRaises(IntegrityError):
             Membership.objects.create(user=user, proposal=proposal, role=Membership.CI)
 
     def test_user_already_member(self):
         proposal = mixer.blend(Proposal)
-        user = mixer.blend(User)
+        user = blend_user()
         mixer.blend(Membership, proposal=proposal, user=user, role=Membership.CI)
         proposal.add_users([user.email], Membership.CI)
         self.assertIn(proposal, user.proposal_set.all())
@@ -92,7 +93,7 @@ class TestProposalInvitation(DramatiqTestCase):
 
     def test_accept(self):
         invitation = mixer.blend(ProposalInvite)
-        user = mixer.blend(User)
+        user = blend_user()
         invitation.accept(user)
         self.assertIn(invitation.proposal, user.proposal_set.all())
 
@@ -100,13 +101,14 @@ class TestProposalInvitation(DramatiqTestCase):
 class TestProposalNotifications(DramatiqTestCase):
     def setUp(self):
         self.proposal = mixer.blend(Proposal)
-        self.user = mixer.blend(User)
+        self.user = blend_user()
         mixer.blend(Membership, user=self.user, proposal=self.proposal)
         self.requestgroup = mixer.blend(RequestGroup, proposal=self.proposal, submitter=self.user, state='PENDING',
                                         observation_type=RequestGroup.NORMAL)
 
     def test_all_proposal_notification(self):
-        mixer.blend(Profile, user=self.user, notifications_enabled=True)
+        self.user.profile.notifications_enabled = True
+        self.user.profile.save()
         download_urls = ['http://download_data/?requestgroup={requestgroup_id}', 'http://download_data/', '']
         for download_url in download_urls:
             download_url_is_in_email = download_url != ''
@@ -130,7 +132,8 @@ class TestProposalNotifications(DramatiqTestCase):
                     self.assertEqual(mail.outbox[0].to, [self.user.email])
 
     def test_single_proposal_notification(self):
-        mixer.blend(Profile, user=self.user, notifications_enabled=False)
+        self.user.profile.notifications_enabled = False
+        self.user.profile.save()
         mixer.blend(ProposalNotification, user=self.user, proposal=self.proposal)
         self.requestgroup.state = 'COMPLETED'
         self.requestgroup.save()
@@ -144,7 +147,8 @@ class TestProposalNotifications(DramatiqTestCase):
         self.assertEqual(mail.outbox[0].to, [self.user.email])
 
     def test_user_loves_notifications(self):
-        mixer.blend(Profile, user=self.user, notifications_enabled=True)
+        self.user.profile.notifications_enabled = True
+        self.user.profile.save()
         mixer.blend(ProposalNotification, user=self.user, proposal=self.proposal)
         self.requestgroup.state = 'COMPLETED'
         self.requestgroup.save()
@@ -157,7 +161,9 @@ class TestProposalNotifications(DramatiqTestCase):
         self.assertEqual(mail.outbox[0].to, [self.user.email])
 
     def test_notifications_only_authored(self):
-        mixer.blend(Profile, user=self.user, notifications_enabled=True, notifications_on_authored_only=True)
+        self.user.profile.notifications_enabled = True
+        self.user.profile.notifications_on_authored_only = True
+        self.user.profile.save()
         self.requestgroup.submitter = self.user
         self.requestgroup.state = 'COMPLETED'
         self.requestgroup.save()
@@ -170,8 +176,10 @@ class TestProposalNotifications(DramatiqTestCase):
         self.assertEqual(mail.outbox[0].to, [self.user.email])
 
     def test_no_notifications_only_authored(self):
-        mixer.blend(Profile, user=self.user, notifications_enabled=True, notifications_on_authored_only=True)
-        self.requestgroup.submitter = mixer.blend(User)
+        self.user.profile.notifications_enabled = True
+        self.user.profile.notifications_on_authored_only = True
+        self.user.profile.save()
+        self.requestgroup.submitter = blend_user()
         self.requestgroup.state = 'COMPLETED'
         self.requestgroup.save()
 
@@ -193,8 +201,8 @@ class TestProposalNotifications(DramatiqTestCase):
 class TestTimeAllocationEmail(DramatiqTestCase):
     def setUp(self):
         super().setUp()
-        self.pi = mixer.blend(User)
-        self.coi = mixer.blend(User)
+        self.pi = blend_user()
+        self.coi = blend_user()
         self.proposal = mixer.blend(Proposal, active=True)
         mixer.blend(Membership, user=self.pi, proposal=self.proposal, role='PI')
         mixer.blend(Membership, user=self.coi, proposal=self.proposal, role='CI')
@@ -254,8 +262,7 @@ class TestProposalUserLimits(TestCase):
         self.proposal = mixer.blend(Proposal)
         semester = mixer.blend(Semester, start=timezone.now(), end=timezone.now() + datetime.timedelta(days=180))
         mixer.blend(TimeAllocation, proposal=self.proposal, semester=semester, instrument_types=['1M0-SCICAM-SBIG'])
-        self.user = mixer.blend(User)
-        mixer.blend(Profile, user=self.user)
+        self.user = blend_user()
         mixer.blend(Membership, user=self.user, proposal=self.proposal, role=Membership.CI)
 
     def test_time_used_for_user(self):
@@ -327,7 +334,7 @@ class TestProposalAdmin(TestCase):
         self.proposals = mixer.cycle(3).blend(Proposal, active=False)
         self.proposal = self.proposals[0]
         now = timezone.now()
-        self.user = mixer.blend(User)
+        self.user = blend_user()
         self.current_semester = mixer.blend(
             Semester, start=now, end=now + datetime.timedelta(days=30))
         self.time_allocation = mixer.blend(TimeAllocation, proposal=self.proposal, semester=self.current_semester, instrument_types=['1M0-SCICAM-SBIG'])

--- a/observation_portal/proposals/viewsets.py
+++ b/observation_portal/proposals/viewsets.py
@@ -3,7 +3,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.permissions import IsAuthenticated, AllowAny, IsAdminUser
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.module_loading import import_string
 from django.conf import settings
 from rest_framework import status

--- a/observation_portal/requestgroups/duration_utils.py
+++ b/observation_portal/requestgroups/duration_utils.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from math import ceil, floor
 from collections import defaultdict
 from django.utils import timezone

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 
 from cerberus import Validator
 from rest_framework import serializers
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.cache import cache
 from django.db import transaction

--- a/observation_portal/requestgroups/target_helpers.py
+++ b/observation_portal/requestgroups/target_helpers.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from numbers import Number
 
 

--- a/observation_portal/sciapplications/models.py
+++ b/observation_portal/sciapplications/models.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.utils import timezone
 from django.contrib.auth.models import User
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.contrib.postgres.fields import ArrayField
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property

--- a/observation_portal/sciapplications/serializers.py
+++ b/observation_portal/sciapplications/serializers.py
@@ -1,7 +1,7 @@
 import os
 from collections import defaultdict
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils import timezone
 from django.db import transaction
 from PyPDF2 import PdfFileReader

--- a/observation_portal/sciapplications/test_admin.py
+++ b/observation_portal/sciapplications/test_admin.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from mixer.backend.django import mixer
 from django_dramatiq.test import DramatiqTestCase
 
+from observation_portal.accounts.test_utils import blend_user
 from observation_portal.proposals.models import Semester, Proposal
 from observation_portal.sciapplications.models import ScienceApplication, Call, Instrument, TimeRequest
 
@@ -28,7 +29,7 @@ def order_mail_invite_then_approval(mailbox):
 class TestSciAppAdmin(DramatiqTestCase):
     def setUp(self):
         self.semester = mixer.blend(Semester)
-        self.user = mixer.blend(User)
+        self.user = blend_user()
         self.admin_user = User.objects.create_superuser('admin', 'admin@example.com', 'password')
         self.client.force_login(self.admin_user)
         self.call = mixer.blend(
@@ -99,7 +100,7 @@ class TestSciAppAdmin(DramatiqTestCase):
         self.assertIn(ScienceApplication.objects.get(pk=app_id_to_port).call.semester.id, str(mail.outbox[0].message()))
 
     def test_email_pi_on_successful_port_when_registered_pi_is_not_submitter(self):
-        other_user = mixer.blend(User)
+        other_user = blend_user()
         app_id_to_port = self.apps[0].id
         ScienceApplication.objects.filter(pk=app_id_to_port).update(status=ScienceApplication.ACCEPTED)
         ScienceApplication.objects.filter(pk=app_id_to_port).update(pi=other_user.email)

--- a/observation_portal/sciapplications/tests.py
+++ b/observation_portal/sciapplications/tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.contrib.auth.models import User
 from mixer.backend.django import mixer
 
+from observation_portal.accounts.test_utils import blend_user
 from observation_portal.sciapplications.models import ScienceApplication, Call, TimeRequest, CoInvestigator, Instrument
 from observation_portal.proposals.models import Semester, Membership, ProposalInvite, ScienceCollaborationAllocation
 
@@ -9,7 +10,7 @@ from observation_portal.proposals.models import Semester, Membership, ProposalIn
 class TestSciAppToProposal(TestCase):
     def setUp(self):
         self.semester = mixer.blend(Semester)
-        self.user = mixer.blend(User)
+        self.user = blend_user()
         self.client.force_login(self.user)
         self.call = mixer.blend(
             Call, semester=self.semester,
@@ -37,7 +38,7 @@ class TestSciAppToProposal(TestCase):
         self.assertTrue(ProposalInvite.objects.filter(proposal=proposal, role=Membership.PI).exists())
 
     def test_create_proposal_with_supplied_existant_pi(self):
-        user = mixer.blend(User)
+        user = blend_user()
         app = mixer.blend(ScienceApplication, submitter=self.user, pi=user.email)
         tr = mixer.blend(TimeRequest, approved=True, science_application=app)
         proposal = app.convert_to_proposal()
@@ -47,7 +48,7 @@ class TestSciAppToProposal(TestCase):
         self.assertFalse(ProposalInvite.objects.filter(proposal=proposal).exists())
 
     def test_create_proposal_with_tags(self):
-        user = mixer.blend(User)
+        user = blend_user()
         app = mixer.blend(ScienceApplication, submitter=self.user, pi=user.email)
         tr = mixer.blend(TimeRequest, approved=True, science_application=app)
         proposal = app.convert_to_proposal()
@@ -70,8 +71,8 @@ class TestSciAppToProposal(TestCase):
 
     def test_create_proposal_with_existant_cois(self):
         app = mixer.blend(ScienceApplication, submitter=self.user, pi='')
-        coi1 = mixer.blend(User, email='1@example.com')
-        coi2 = mixer.blend(User, email='2@example.com')
+        coi1 = blend_user(user_params={'email': '1@example.com'})
+        coi2 = blend_user(user_params={'email': '2@example.com'})
         mixer.blend(CoInvestigator, email='1@example.com', science_application=app)
         mixer.blend(CoInvestigator, email='2@example.com', science_application=app)
         mixer.blend(CoInvestigator, email='3@example.com', science_application=app)
@@ -103,8 +104,8 @@ class TestSciAppToProposal(TestCase):
         self.assertEqual(proposal.timeallocation_set.get(semester=other_semester).instrument_types[0], it2.code)
 
     def test_create_collab_proposal(self):
-        pi = mixer.blend(User)
-        submitter = mixer.blend(User)
+        pi = blend_user()
+        submitter = blend_user()
         sca = mixer.blend(ScienceCollaborationAllocation, admin=submitter)
         app = mixer.blend(ScienceApplication, submitter=submitter, pi=pi.email)
         tr = mixer.blend(TimeRequest, approved=True, science_application=app)

--- a/observation_portal/sciapplications/tests.py
+++ b/observation_portal/sciapplications/tests.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-from django.contrib.auth.models import User
 from mixer.backend.django import mixer
 
 from observation_portal.accounts.test_utils import blend_user

--- a/observation_portal/settings.py
+++ b/observation_portal/settings.py
@@ -307,6 +307,13 @@ LOGGING = {
 MAX_IPP_VALUE = float(os.getenv('MAX_IPP_VALUE', 2.0))  # the maximum allowed value of ipp
 MIN_IPP_VALUE = float(os.getenv('MIN_IPP_VALUE', 0.5))  # the minimum allowed value of ipp
 PROPOSAL_TIME_OVERUSE_ALLOWANCE = float(os.getenv('PROPOSAL_TIME_OVERUSE_ALLOWANCE', 1.1))  # amount of leeway in a proposals timeallocation before rejecting that request
+
+## This is a list of base URLs for each OAuth Client application which we want this Oauth server
+## to update the token of a user in when the token is revoked and created.
+OAUTH_CLIENT_APPS_BASE_URLS = get_list_from_env('OAUTH_CLIENT_APPS_BASE_URLS', '')
+## This key must match the key setup in the Oauth Client applications to authenticate this as the server
+OAUTH_SERVER_KEY = os.getenv('OAUTH_SERVER_KEY', '')
+
 ## Serializer setup - used to allow overriding of serializers
 SERIALIZERS = {
     'observations': {


### PR DESCRIPTION
This adds `is_superuser` to the returned profile data in the API. It adds signals for watching User or Profile model updates, which then trigger a client view's users to be updated as well. This also occurs during a revoke_token API call. There is a management command that can be used to update all users in a client application, which will be useful to initially seed those applications user accounts. 