### PR TITLE
Make sure to set some fields to their default prior to copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ This project adheres to semantic versioning.
 ### Changed
 ### Removed
 
-## [4.2.0] - 2022-03-16
+## [4.2.1] - 2022-03-22
+
+Fix issue when copying a science application which has been assigned a TAC ranking
+
+### Changed
+- Set TAC ranking, TAC priority and proposal to their default values when copying a Science Application to a new draft
+
+## [4.2.0] - 2022-03-21
 
 Add ability to copy previous science applications for use in a new call.
 

--- a/observation_portal/sciapplications/test_api.py
+++ b/observation_portal/sciapplications/test_api.py
@@ -1124,9 +1124,12 @@ class TestCopySciApp(DramatiqTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(science_applications.count(), 2)
         self.assertEqual(sci_app_copy.status, ScienceApplication.DRAFT)
-        self.assertNotEqual(sci_app_copy.pdf.name, science_applications[1].pdf.name)
+        self.assertNotEqual(sci_app_copy.pdf.name, old_sci_app.pdf.name)
         self.assertEqual(sci_app_copy.call.id, self.current_sci_call.id)
         self.assertEqual(sci_app_copy.call.semester.id, self.current_sci_call.semester.id)
+        self.assertEqual(sci_app_copy.tac_rank, 0)
+        self.assertEqual(sci_app_copy.tac_priority, 0)
+        self.assertEqual(sci_app_copy.proposal, None)
 
         self.assertQuerysetEqual(sci_app_copy.coinvestigator_set.all(), old_sci_app.coinvestigator_set.all())
         self.assertQuerysetEqual(sci_app_copy.timerequest_set.all(), old_sci_app.timerequest_set.all())

--- a/observation_portal/sciapplications/viewsets.py
+++ b/observation_portal/sciapplications/viewsets.py
@@ -69,6 +69,9 @@ class ScienceApplicationViewSet(viewsets.ModelViewSet):
             sci_app._state.adding = True
             sci_app.status = 'DRAFT'
             sci_app.call = active_calls[0]
+            sci_app.proposal = None
+            sci_app.tac_rank = 0
+            sci_app.tac_priority = 0
             # save the model to generate a new primary key
             sci_app.save()
             # Now add copies of the COIs and Time Requests in the new Semester


### PR DESCRIPTION
The proposal, tac rank and tac priority are all set when a science application is evaluated