### PR TITLE
Adjust expanded configurations priority in a repeat_configuration obs…

### DIFF
--- a/observation_portal/observations/models.py
+++ b/observation_portal/observations/models.py
@@ -52,6 +52,7 @@ def get_expanded_configurations(observation, configurations):
             expanded_configurations[-1]['state'] = config_status.state
             expanded_configurations[-1]['instrument_name'] = config_status.instrument_name
             expanded_configurations[-1]['guide_camera_name'] = config_status.guide_camera_name
+            expanded_configurations[-1]['priority'] += (repeat_index * len(configurations))
             if hasattr(config_status, 'summary'):
                 expanded_configurations[-1]['summary'] = config_status.summary.as_dict()
             else:

--- a/observation_portal/observations/test/tests.py
+++ b/observation_portal/observations/test/tests.py
@@ -1046,9 +1046,12 @@ class TestPostObservationApi(TestObservationApiBase):
 
         # Ensure configurations are repeated, and configuration statuses are ascending
         previous_configuration_status_id = 0
+        previous_priority = 0
         for i, configuration in enumerate(observation['request']['configurations']):
             self.assertEqual(expected_configuration_ids[i], configuration['id'])
             self.assertGreater(configuration['configuration_status'], previous_configuration_status_id)
+            self.assertGreater(configuration['priority'], previous_priority)
+            previous_priority = configuration['priority']
             previous_configuration_status_id = configuration['configuration_status']
 
 


### PR DESCRIPTION
…ervation

Site-software uses the configuration priority to choose the ordering for configurations its observing, so not changing these causes site-software to try to observe them in a different order than what is intended by the configuration status order