### PR TITLE
Add created_before and created_after filters to observations endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to semantic versioning.
 
 ### Removed
 
+## [4.3.4] - 2022-06-23
+
+### Added
+- Added range filters for /api/observations `created_time` field
+
 ## [4.3.3] - 2022-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to semantic versioning.
 ### Added
 - Added range filters for /api/observations `created` datetime field
 
-## [4.4.0] - 2022-05-14
+## [4.4.0] - 2022-06-14
 
 ### Changed
 - Fix: accept pending proposal invites on bulk user creation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to semantic versioning.
 
 ### Removed
 
-## [4.3.4] - 2022-06-23
+## [4.4.1] - 2022-06-23
 
 ### Added
 - Added range filters for /api/observations `created_time` field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ This project adheres to semantic versioning.
 ## [4.4.1] - 2022-06-23
 
 ### Added
-- Added range filters for /api/observations `created_time` field
+- Added range filters for /api/observations `created` datetime field
+
+## [4.4.0] - 2022-05-14
+
+### Changed
+- Fix: accept pending proposal invites on bulk user creation
 
 ## [4.3.3] - 2022-05-31
 

--- a/observation_portal/observations/filters.py
+++ b/observation_portal/observations/filters.py
@@ -45,6 +45,18 @@ class ObservationFilter(mixins.CustomIsoDateTimeFilterMixin, django_filters.Filt
         label='Modified After (Inclusive)',
         widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
     )
+    created_after = django_filters.IsoDateTimeFilter(
+        field_name='created',
+        lookup_expr='gte',
+        label='Created After (Inclusive)',
+        widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
+    )
+    created_before = django_filters.IsoDateTimeFilter(
+        field_name='created',
+        lookup_expr='lt',
+        label='Created Before',
+        widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
+    )
     request_id = django_filters.NumberFilter(field_name='request__id')
     request_group_id = django_filters.NumberFilter(field_name='request__request_group__id', label='Request Group ID')
     state = django_filters.MultipleChoiceFilter(choices=Observation.STATE_CHOICES, field_name='state')


### PR DESCRIPTION
This is useful for scheduler research, since we are trying to bound our queries to a single scheduler run