### PR TITLE
Cancel or Delete pending observations in the future when request is c…

### DIFF
--- a/observation_portal/common/state_changes.py
+++ b/observation_portal/common/state_changes.py
@@ -102,6 +102,9 @@ def on_request_state_change(old_request_state, new_request):
             ipp_value = new_request.request_group.ipp_value
             if ipp_value >= 1.0:
                 modify_ipp_time_from_request(ipp_value, new_request, 'credit')
+    if new_request.state == 'CANCELED':
+        # Ensure its pending Observations are cancelled here
+        Observation.cancel(new_request.observation_set.filter(state='PENDING'))
 
 
 def on_requestgroup_state_change(old_requestgroup_state, new_requestgroup):

--- a/observation_portal/common/test_state_changes.py
+++ b/observation_portal/common/test_state_changes.py
@@ -224,7 +224,10 @@ class TestStateChanges(SetTimeMixin, TestCase):
         request = self.requestgroup.requests.first()
         request.state = 'CANCELED'
         request.save()
+        # Reset the Observation state to PENDING since it will have been cancelled now...
         observation = request.observation_set.first()
+        observation.state = 'PENDING'
+        observation.save()
         for cs in observation.configuration_statuses.all():
             summary = cs.summary
             summary.time_completed = 1000


### PR DESCRIPTION
…ancelled

This is for the operations story [here]( https://www.pivotaltracker.com/story/show/183704391). It applies to all Request types, and cancel, aborts, or deletes their pending observations in the future - it should be most useful for engineering with cancelling direct submissions by cancelling the associated request. 