### PR TITLE
Add ConfigurationTypeValidationHelper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ This project adheres to semantic versioning.
 
 ### Removed
 
+## [4.4.9] - 2023-02-28
+
+### Added
+- Support for validating instrument configurations via validation schema defined in the Configuration Database's ConfigurationTypeProperties.
+This allows for specific per-instrument type/per-configuration type validation of instrument configs submitted directly or via the /api/requestgroups/ endpoint.
+
+
 ## [4.4.8] - 2023-01-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to semantic versioning.
 
 ### Added
 - Support for validating instrument configurations via validation schema defined in the Configuration Database's ConfigurationTypeProperties.
-This allows for specific per-instrument type/per-configuration type validation of instrument configs submitted directly or via the /api/requestgroups/ endpoint.
+This allows for specific per-instrument type/per-configuration type validation of instrument configs within direct submissions to /api/schedule or via the /api/requestgroups/ endpoint.
 
 
 ## [4.4.8] - 2023-01-31

--- a/observation_portal/observations/serializers.py
+++ b/observation_portal/observations/serializers.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from observation_portal.common.configdb import configdb
 from observation_portal.observations.models import Observation, ConfigurationStatus, Summary
 from observation_portal.requestgroups.models import RequestGroup, AcquisitionConfig, GuidingConfig, Target
+from observation_portal.requestgroups.serializers import ConfigurationTypeValidationHelper
 from observation_portal.proposals.models import Proposal
 
 import logging
@@ -121,6 +122,12 @@ class ObservationConfigurationSerializer(import_string(settings.SERIALIZERS['req
             target_serializer = import_string(settings.SERIALIZERS['requestgroups']['Target'])(data=validated_data['target'])
             if not target_serializer.is_valid():
                 raise serializers.ValidationError(target_serializer.errors)
+
+        for i, instrument_config in enumerate(validated_data['instrument_configs']):
+            configuration_type_validation_helper = ConfigurationTypeValidationHelper(data['instrument_type'], data['type'])
+            instrument_config = configuration_type_validation_helper.validate(instrument_config)
+            validated_data['instrument_configs'][i] = instrument_config
+
         return validated_data
 
 

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -384,6 +384,9 @@ class ConfigurationSerializer(ExtraParamsFormatter, serializers.ModelSerializer)
             instrument_type_validation_helper = InstrumentTypeValidationHelper(instrument_type)
             instrument_config = instrument_type_validation_helper.validate(instrument_config)
 
+            configuration_type_validation_helper = ConfigurationTypeValidationHelper(data['instrument_type'], data['type'])
+            instrument_config = configuration_type_validation_helper.validate(instrument_config)
+
             data['instrument_configs'][i] = instrument_config
 
             # Validate the rotator modes

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -180,6 +180,24 @@ class ModeValidationHelper(ValidationHelper):
         return ''
 
 
+class ConfigurationTypeValidationHelper(ValidationHelper):
+    """Class used to validate config based on configuration type"""
+    def __init__(self, instrument_type: str, configuration_type: str):
+        self._instrument_type = instrument_type.lower()
+        self._configuration_type = configuration_type
+
+    def validate(self, config_dict: dict) -> dict:
+        configuration_type_properties = configdb.get_configuration_types(self._instrument_type)[self._configuration_type]
+        validation_schema = configuration_type_properties.get('validation_schema', {})
+        validator, validated_config_dict = self._validate_document(config_dict, validation_schema)
+        if validator.errors:
+            raise serializers.ValidationError(_(
+                f'Invalid configuration: {self._cerberus_validation_error_to_str(validator.errors)}'
+            ))
+
+        return validated_config_dict
+
+
 class CadenceSerializer(serializers.Serializer):
     start = serializers.DateTimeField()
     end = serializers.DateTimeField()

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -384,7 +384,7 @@ class ConfigurationSerializer(ExtraParamsFormatter, serializers.ModelSerializer)
             instrument_type_validation_helper = InstrumentTypeValidationHelper(instrument_type)
             instrument_config = instrument_type_validation_helper.validate(instrument_config)
 
-            configuration_type_validation_helper = ConfigurationTypeValidationHelper(data['instrument_type'], data['type'])
+            configuration_type_validation_helper = ConfigurationTypeValidationHelper(instrument_type, data['type'])
             instrument_config = configuration_type_validation_helper.validate(instrument_config)
 
             data['instrument_configs'][i] = instrument_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-ocs-observation-portal"
-version = "4.4.8"
+version = "4.4.9"
 description = "The Observatory Control System (OCS) Observation Portal django apps"
 license = "GPL-3.0-only"
 authors = ["Observatory Control System Project <ocs@lco.global>"]


### PR DESCRIPTION
This is meant to validate instrument configs based on the validation schema specified in the ConfigurationTypeProperties model for that particular instrument type/configuration type.