### PR TITLE
Add tags to proposal section of timeallocations action on semester serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project adheres to semantic versioning.
 ### Removed
 
 
+## [4.5.0] - 2023-03-28
+
+### Changed
+- Add proposal tags to response from semesters timeallocation action 
+
+
 ## [4.4.12] - 2023-03-09
 
 ### Changed

--- a/observation_portal/common/doc_examples.py
+++ b/observation_portal/common/doc_examples.py
@@ -533,6 +533,7 @@ EXAMPLE_RESPONSES = {
                     "id": "PROPOSAL-A-2021",
                     "tac_priority": 20,
                     "num_users": 5,
+                    "tags": ['student'],
                     "pis": [{"first_name": "Eleanor", "last_name": "Arroway"}],
                 },
             }

--- a/observation_portal/proposals/viewsets.py
+++ b/observation_portal/proposals/viewsets.py
@@ -174,6 +174,7 @@ class SemesterViewSet(viewsets.ReadOnlyModelViewSet):
                 'id': timeallocation.proposal.id,
                 'tac_priority': timeallocation.proposal.tac_priority,
                 'num_users': memberships.count(),
+                'tags': timeallocation.proposal.tags,
                 'pis': [
                     {
                         'first_name': mem.user.first_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-ocs-observation-portal"
-version = "4.4.12"
+version = "4.5.0"
 description = "The Observatory Control System (OCS) Observation Portal django apps"
 license = "GPL-3.0-only"
 authors = ["Observatory Control System Project <ocs@lco.global>"]


### PR DESCRIPTION
This is so that we can display them in the `/proposals/semesteradmin` table - requested by Nikolaus/Lisa

You can see the tags are now included in the semesteradmin table at http://observation-portal-dev.lco.gtn/proposals/semesteradmin/2022A

Will open a frontend PR shortly.