### PR TITLE
Feature/register email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to semantic versioning.
 
 ### Removed
 
+## [4.7.2] - 2023-05-23
+
+### Changed
+- Updated invitation email to include email address in URL param
+- Plumb email param for /accounts/register to registration form
 
 ## [4.5.1] - 2023-04-03
 

--- a/observation_portal/accounts/forms.py
+++ b/observation_portal/accounts/forms.py
@@ -26,6 +26,12 @@ class CustomRegistrationForm(RegistrationFormTermsOfService, RegistrationFormUni
             'username': 'Will be present under the USERID fits header.',
         }
 
+    def __init__(self, email=None, *args, **kwargs):
+        kwargs.update(initial={'email': email})
+        super().__init__(*args, **kwargs)
+        if email is not None:
+            self.fields['email'].widget.attrs['readonly'] = True
+
     def save(self, commit=True):
         new_user_instance = super().save(commit=True)
         Profile.objects.create(

--- a/observation_portal/accounts/forms.py
+++ b/observation_portal/accounts/forms.py
@@ -30,6 +30,7 @@ class CustomRegistrationForm(RegistrationFormTermsOfService, RegistrationFormUni
         kwargs.update(initial={'email': email})
         super().__init__(*args, **kwargs)
         if email is not None:
+            # make email in form read-only if it has been provided from the view
             self.fields['email'].widget.attrs['readonly'] = True
 
     def save(self, commit=True):

--- a/observation_portal/accounts/urls.py
+++ b/observation_portal/accounts/urls.py
@@ -1,7 +1,7 @@
 from django.urls import re_path, include, path
 from django.views.generic.base import TemplateView
-from registration.backends.default.views import RegistrationView
 
+from observation_portal.accounts.views import CustomRegistrationView
 from observation_portal.accounts.forms import CustomRegistrationForm
 
 from .views import (
@@ -11,7 +11,7 @@ from .views import (
 )
 
 urlpatterns = [
-    re_path(r'^register/$', RegistrationView.as_view(form_class=CustomRegistrationForm), name='registration_register'),
+    re_path(r'^register/(?P<email>.*)/?', CustomRegistrationView.as_view(form_class=CustomRegistrationForm), name='registration_register'),
     re_path(r'^loggedinstate/$', TemplateView.as_view(template_name='auth/logged_in_state.html'), name='logged-in-state'),
     path("login/", CustomLoginView.as_view(), name="auth_login"),
     path("password/change/", CustomPasswordChangeView.as_view(), name="auth_password_change"),

--- a/observation_portal/accounts/urls.py
+++ b/observation_portal/accounts/urls.py
@@ -11,7 +11,7 @@ from .views import (
 )
 
 urlpatterns = [
-    re_path(r'^register/(?P<email>.*)/?', CustomRegistrationView.as_view(form_class=CustomRegistrationForm), name='registration_register'),
+    re_path(r'^register/$', CustomRegistrationView.as_view(form_class=CustomRegistrationForm), name='registration_register'),
     re_path(r'^loggedinstate/$', TemplateView.as_view(template_name='auth/logged_in_state.html'), name='logged-in-state'),
     path("login/", CustomLoginView.as_view(), name="auth_login"),
     path("password/change/", CustomPasswordChangeView.as_view(), name="auth_password_change"),

--- a/observation_portal/accounts/views.py
+++ b/observation_portal/accounts/views.py
@@ -157,7 +157,7 @@ class CustomPasswordResetConfirmView(ResetPasswordExpirationFormMixin, PasswordR
 
 
 class CustomRegistrationView(RegistrationView):
-    # Pass url parameters from the view to the form  
+    # Pass url parameters from the view to the form
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs.update({'email': self.request.GET.get('email')})

--- a/observation_portal/accounts/views.py
+++ b/observation_portal/accounts/views.py
@@ -7,12 +7,14 @@ from django.contrib.auth.views import LoginView, PasswordChangeView, PasswordRes
 from django.utils.module_loading import import_string
 from django.conf import settings
 from django.urls import reverse_lazy
+from django.http import HttpResponseRedirect
 from rest_framework.generics import CreateAPIView, RetrieveUpdateAPIView
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.authtoken.models import Token
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from registration.backends.default.views import RegistrationView
 
 from observation_portal.accounts.models import Profile
 from observation_portal.accounts.tasks import send_mail, update_or_create_client_applications_user
@@ -153,3 +155,11 @@ class CustomPasswordChangeView(ResetPasswordExpirationFormMixin, PasswordChangeV
 
 class CustomPasswordResetConfirmView(ResetPasswordExpirationFormMixin, PasswordResetConfirmView):
     success_url = reverse_lazy("auth_password_reset_complete")
+
+
+class CustomRegistrationView(RegistrationView):
+    # Pass url parameters from the view to the form
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs.update({'email': self.request.GET.get('email')})
+        return kwargs

--- a/observation_portal/accounts/views.py
+++ b/observation_portal/accounts/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.views import LoginView, PasswordChangeView, PasswordRes
 from django.utils.module_loading import import_string
 from django.conf import settings
 from django.urls import reverse_lazy
-from django.http import HttpResponseRedirect
 from rest_framework.generics import CreateAPIView, RetrieveUpdateAPIView
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.authtoken.models import Token
@@ -158,7 +157,7 @@ class CustomPasswordResetConfirmView(ResetPasswordExpirationFormMixin, PasswordR
 
 
 class CustomRegistrationView(RegistrationView):
-    # Pass url parameters from the view to the form
+    # Pass url parameters from the view to the form  
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs.update({'email': self.request.GET.get('email')})

--- a/observation_portal/proposals/models.py
+++ b/observation_portal/proposals/models.py
@@ -11,6 +11,8 @@ from django.utils.html import strip_tags
 from django.utils.module_loading import import_string
 from django.conf import settings
 from collections import namedtuple
+
+from urllib.parse import urljoin
 import logging
 
 from observation_portal.accounts.tasks import send_mail
@@ -336,7 +338,7 @@ class ProposalInvite(models.Model):
             'proposals/invitation.txt',
             {
                 'proposal': self.proposal,
-                'url': reverse('registration_register'),
+                'url': urljoin(reverse('registration_register'), f'/?email={self.email}'),
                 'organization_name': settings.ORGANIZATION_NAME,
                 'observation_portal_base_url': settings.OBSERVATION_PORTAL_BASE_URL
             }


### PR DESCRIPTION
This grabs the `?email=` URL param and plumbs it down into the form if it exists. Also updates the registration URL to include the email param.

I'll have a separate PR for the frontend which includes a redirect to the homepage if the user attempts to register an account if logged in