### PR TITLE
Make email in form editable by users

### DIFF
--- a/observation_portal/accounts/forms.py
+++ b/observation_portal/accounts/forms.py
@@ -29,9 +29,6 @@ class CustomRegistrationForm(RegistrationFormTermsOfService, RegistrationFormUni
     def __init__(self, email=None, *args, **kwargs):
         kwargs.update(initial={'email': email})
         super().__init__(*args, **kwargs)
-        if email is not None:
-            # make email in form read-only if it has been provided from the view
-            self.fields['email'].widget.attrs['readonly'] = True
 
     def save(self, commit=True):
         new_user_instance = super().save(commit=True)


### PR DESCRIPTION
By doing this we encourage the user to use the email that the invite was sent to, but if they know better they may override it.

I have this deployed to dev - e.g. http://observation-portal-dev.lco.gtn/accounts/register/?email=mdaily@lco.global