### PR TITLE
Fix Telescope States and Telescope Availability - No OS Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to semantic versioning.
 
 ### Removed
 
+## [4.8.0] - 2023-09-07
+
+### Changed
+- Fix /api/telescope_states to return a useful error message and 502 when no connection to OpenSearch is available.
+
 ## [4.7.2] - 2023-05-23
 
 ### Changed

--- a/observation_portal/requestgroups/test/test_views.py
+++ b/observation_portal/requestgroups/test/test_views.py
@@ -37,7 +37,7 @@ class TestTelescopeStates(TelescopeStatesFromFile):
     def test_opensearch_down(self, os_patch):
         response = self.client.get(reverse('api:telescope_availability') +
                                    '?start=2016-10-1T1:23:44&end=2016-10-10T22:22:2')
-        self.assertContains(response, 'ConnectionError')
+        self.assertContains(response, 'ConnectionError', status_code=502)
 
 
 class TestInstrumentInformation(TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-ocs-observation-portal"
-version = "4.7.7"
+version = "4.8.0"
 description = "The Observatory Control System (OCS) Observation Portal django apps"
 license = "GPL-3.0-only"
 authors = ["Observatory Control System Project <ocs@lco.global>"]


### PR DESCRIPTION
We should return a useful message, with an appropriate HTTP status code when OpenSearch cannot be reached. The status code 502 [indicates](https://www.rfc-editor.org/rfc/rfc9110.html#name-502-bad-gateway) "...that the server, while acting as a gateway or proxy, received an invalid response from an inbound server it accessed while attempting to fulfill the request."

