### PR TITLE
Fix registration URL

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,10 @@ jobs:
         DB_PORT: 5432
     - name: Generate and send coveralls report
       uses: coverallsapp/github-action@v2
+      with:
+        parallel: true
+        flag-name: run-${{ matrix.python-version }}
+
 
   publish_to_pypi:
     # Only run this job if the run_tests job has succeeded, and if
@@ -103,3 +107,11 @@ jobs:
           pull: true
           push: true
           tags: ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
+
+finish:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Close parallel build
+      uses: coverallsapp/github-action@v1
+      with:
+        parallel-finished: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,8 +53,14 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         parallel: true
-        flag-name: run-${{ matrix.python-version }}
-
+  finish:
+    runs-on: ubuntu-latest
+    needs: run_tests
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v1
+        with:
+          parallel-finished: true
 
   publish_to_pypi:
     # Only run this job if the run_tests job has succeeded, and if
@@ -107,11 +113,3 @@ jobs:
           pull: true
           push: true
           tags: ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
-
-finish:
-  runs-on: ubuntu-latest
-  steps:
-    - name: Close parallel build
-      uses: coverallsapp/github-action@v1
-      with:
-        parallel-finished: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,11 +50,7 @@ jobs:
         DB_HOST: localhost
         DB_PORT: 5432
     - name: Generate and send coveralls report
-      run: |
-        pip install 'coveralls<3.3'
-        coveralls --service=github
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: coverallsapp/github-action@v2
 
   publish_to_pypi:
     # Only run this job if the run_tests job has succeeded, and if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to semantic versioning.
 
 ### Removed
 
+## [4.8.2] - 2023-11-09
+
+### Changed
+- Fixed URL generation for proposal invites
+
 ## [4.8.1] - 2023-09-20
 
 ### Added

--- a/observation_portal/proposals/models.py
+++ b/observation_portal/proposals/models.py
@@ -338,7 +338,7 @@ class ProposalInvite(models.Model):
             'proposals/invitation.txt',
             {
                 'proposal': self.proposal,
-                'url': urljoin(reverse('registration_register'), f'/?email={self.email}'),
+                'url': urljoin(reverse('registration_register'), f'?email={self.email}'),
                 'organization_name': settings.ORGANIZATION_NAME,
                 'observation_portal_base_url': settings.OBSERVATION_PORTAL_BASE_URL
             }

--- a/observation_portal/proposals/tests.py
+++ b/observation_portal/proposals/tests.py
@@ -89,6 +89,7 @@ class TestProposalInvitation(DramatiqTestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn(invitation.proposal.id, str(mail.outbox[0].message()))
         self.assertEqual(mail.outbox[0].to, [invitation.email])
+        self.assertIn(reverse('registration_register'), str(mail.outbox[0].message()))
 
     def test_accept(self):
         invitation = mixer.blend(ProposalInvite)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-ocs-observation-portal"
-version = "4.8.1"
+version = "4.8.2"
 description = "The Observatory Control System (OCS) Observation Portal django apps"
 license = "GPL-3.0-only"
 authors = ["Observatory Control System Project <ocs@lco.global>"]


### PR DESCRIPTION
I really don't understand this one, but apparently urllb stopped playing nicely with us when we had double-slashes. Perhaps this never worked?

Users were getting URLs of the form https://observe.lco.global/?email=wesleyotieno2001@gmail.com instead of https://observe.lco.global/accounts/register/?email=wesleyotieno2001@gmail.com

In any case, I've updated a test too. I'm a little busy today but can we coordinate a deploy sometime?