### PR TITLE
Added realtime availability endpoint

### DIFF
--- a/observation_portal/observations/realtime.py
+++ b/observation_portal/observations/realtime.py
@@ -2,15 +2,18 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.utils import timezone
+from django.contrib.auth.models import User
 
 from observation_portal.proposals.models import Semester
 from observation_portal.common.configdb import configdb
 from observation_portal.common.rise_set_utils import filtered_dark_intervalset_for_telescope
 
 
-def get_realtime_availability(user, telescope_filter = None):
+def get_realtime_availability(user: User, telescope_filter: str = ''):
     """ Returns a dict of lists of availability intervals for each
         telescope, limited to just a specific telescope if specified
+
+        telescope_filter should be of the form telescope_code.enclosure_code.site_code (i.e. 0m4a.clma.tst)
     """
     # Get the set of telescopes available for a users proposals and optionally filtered by the telescope param
     instrument_types_available = set()
@@ -25,7 +28,7 @@ def get_realtime_availability(user, telescope_filter = None):
                         if not telescope_filter or key == telescope_filter:
                             telescopes_availability[key] = []
 
-    # Now go through each telesope and get its availability intervals
+    # Now go through each telescope and get its availability intervals
     start = timezone.now() + timedelta(minutes=settings.REAL_TIME_AVAILABILITY_MINUTES_IN)
     end = start + timedelta(days=settings.REAL_TIME_AVAILABILITY_DAYS_OUT)
     for resource in telescopes_availability.keys():
@@ -37,7 +40,7 @@ def get_realtime_availability(user, telescope_filter = None):
     return telescopes_availability
 
 
-def realtime_time_available(instrument_types, proposal):
+def realtime_time_available(instrument_types: list[str], proposal: str):
     """ Returns the (max) realtime time available on the proposal given a set of
         potential instrument_types. The instrument_types are really just a standin for
         the telescope, since real time blocks are per telescope and block the whole telescope.

--- a/observation_portal/observations/realtime.py
+++ b/observation_portal/observations/realtime.py
@@ -23,7 +23,7 @@ def get_realtime_availability(user, telescope_filter = None):
                     telescope_info = configdb.get_telescopes_with_instrument_type_and_location(instrument_type)
                     for key in telescope_info:
                         if not telescope_filter or key == telescope_filter:
-                            telescopes_availability[key] = []   
+                            telescopes_availability[key] = []
 
     # Now go through each telesope and get its availability intervals
     start = timezone.now() + timedelta(minutes=settings.REAL_TIME_AVAILABILITY_MINUTES_IN)

--- a/observation_portal/observations/realtime.py
+++ b/observation_portal/observations/realtime.py
@@ -1,0 +1,52 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+from observation_portal.proposals.models import Semester
+from observation_portal.common.configdb import configdb
+from observation_portal.common.rise_set_utils import filtered_dark_intervalset_for_telescope
+
+
+def get_realtime_availability(user, telescope_filter = None):
+    """ Returns a dict of lists of availability intervals for each
+        telescope, limited to just a specific telescope if specified
+    """
+    # Get the set of telescopes available for a users proposals and optionally filtered by the telescope param
+    instrument_types_available = set()
+    telescopes_availability = {}
+    for proposal in user.profile.current_proposals:
+        for ta in proposal.timeallocation_set.filter(semester=Semester.current_semesters().first()):
+            if ta.realtime_allocation > 0 and ta.realtime_time_used < ta.realtime_allocation:
+                for instrument_type in ta.instrument_types:
+                    instrument_types_available.add(instrument_type)
+                    telescope_info = configdb.get_telescopes_with_instrument_type_and_location(instrument_type)
+                    for key in telescope_info:
+                        if not telescope_filter or key == telescope_filter:
+                            telescopes_availability[key] = []   
+
+    # Now go through each telesope and get its availability intervals
+    start = timezone.now() + timedelta(minutes=settings.REAL_TIME_AVAILABILITY_MINUTES_IN)
+    end = start + timedelta(days=settings.REAL_TIME_AVAILABILITY_DAYS_OUT)
+    for resource in telescopes_availability.keys():
+        telescope, enclosure, site = resource.split('.')
+        intervals = filtered_dark_intervalset_for_telescope(start, end, site, enclosure, telescope)
+        for interval in intervals.toTupleList():
+            telescopes_availability[resource].append([interval[0].isoformat(), interval[1].isoformat()])
+
+    return telescopes_availability
+
+
+def realtime_time_available(instrument_types, proposal):
+    """ Returns the (max) realtime time available on the proposal given a set of
+        potential instrument_types. The instrument_types are really just a standin for
+        the telescope, since real time blocks are per telescope and block the whole telescope.
+    """
+    realtime_available = 0.0
+    for ta in proposal.timeallocation_set.filter(semester=Semester.current_semesters().first()):
+        for instrument_type in ta.instrument_types:
+            if instrument_type.upper() in instrument_types:
+                # Just return the max time allocation available since its possible to have multiple that match
+                realtime_available = max(realtime_available, ta.realtime_allocation - ta.realtime_time_used)
+                continue
+    return realtime_available

--- a/observation_portal/observations/realtime.py
+++ b/observation_portal/observations/realtime.py
@@ -40,7 +40,7 @@ def get_realtime_availability(user: User, telescope_filter: str = ''):
     return telescopes_availability
 
 
-def realtime_time_available(instrument_types: list[str], proposal: str):
+def realtime_time_available(instrument_types: list, proposal: str):
     """ Returns the (max) realtime time available on the proposal given a set of
         potential instrument_types. The instrument_types are really just a standin for
         the telescope, since real time blocks are per telescope and block the whole telescope.

--- a/observation_portal/observations/serializers.py
+++ b/observation_portal/observations/serializers.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from observation_portal.common.configdb import configdb
 from observation_portal.common.rise_set_utils import is_interval_available_for_telescope
 from observation_portal.observations.models import Observation, ConfigurationStatus, Summary
-from observation_portal.observations.time_accounting import realtime_time_available
+from observation_portal.observations.realtime import realtime_time_available
 from observation_portal.requestgroups.models import RequestGroup, Request, AcquisitionConfig, GuidingConfig, Target
 from observation_portal.requestgroups.serializers import ConfigurationTypeValidationHelper
 from observation_portal.proposals.models import Proposal

--- a/observation_portal/observations/test/tests.py
+++ b/observation_portal/observations/test/tests.py
@@ -664,6 +664,9 @@ class TestRealTimeApi(SetTimeMixin, APITestCase):
         # Check that the downtime interval is not within the available intervals
         blocked_interval = Intervals([(datetime(2016, 9, 5, 21, 5, tzinfo=timezone.utc), datetime(2016, 9, 5, 22, tzinfo=timezone.utc))])
         self.assertTrue(available_intervals.intersect([blocked_interval]).is_empty())
+        # Make sure the same times the next day are available so we know using the downtime was real
+        free_interval = Intervals([(datetime(2016, 9, 6, 21, 5, tzinfo=timezone.utc), datetime(2016, 9, 6, 22, tzinfo=timezone.utc))])
+        self.assertFalse(available_intervals.intersect([free_interval]).is_empty())
 
 
 class TestObservationApiBase(SetTimeMixin, APITestCase):

--- a/observation_portal/observations/time_accounting.py
+++ b/observation_portal/observations/time_accounting.py
@@ -102,21 +102,6 @@ def configuration_time_used(summary, observation_type):
     return configuration_time
 
 
-def realtime_time_available(instrument_types, proposal):
-    """ Returns the (max) realtime time available on the proposal given a set of
-        potential instrument_types. The instrument_types are really just a standin for
-        the telescope, since real time blocks are per telescope and block the whole telescope.
-    """
-    realtime_available = 0.0
-    for ta in proposal.timeallocation_set.filter(semester=Semester.current_semesters().first()):
-        for instrument_type in ta.instrument_types:
-            if instrument_type.upper() in instrument_types:
-                # Just return the max time allocation available since its possible to have multiple that match
-                realtime_available = max(realtime_available, ta.realtime_allocation - ta.realtime_time_used)
-                continue
-    return realtime_available
-
-
 def debit_realtime_time_allocation(site, enclosure, telescope, proposal, hours):
     """ Attempts to debit the largest suitable time allocation for a real time observation
         If hours is negative, it will act as a credit rather than a debit.

--- a/observation_portal/settings.py
+++ b/observation_portal/settings.py
@@ -253,6 +253,11 @@ OPENSEARCH_URL = os.getenv('OPENSEARCH_URL', 'http://localhost')
 CONFIGDB_URL = os.getenv('CONFIGDB_URL', 'http://localhost')
 DOWNTIMEDB_URL = os.getenv('DOWNTIMEDB_URL', 'http://localhost')
 
+# Real time session booking variables for availiability
+# Availability from (current time + minutes in) to (current time + minutes in + days out)
+REAL_TIME_AVAILABILITY_DAYS_OUT = int(os.getenv('REAL_TIME_AVAILABILITY_DAYS_OUT', 7))
+REAL_TIME_AVAILABILITY_MINUTES_IN = int(os.getenv('REAL_TIME_AVAILABILITY_MINUTES_IN', 60))
+
 REQUESTGROUP_DATA_DOWNLOAD_URL = os.getenv('REQUESTGROUP_DATA_DOWNLOAD_URL', '')  # use {requestgroup_id} to have it substituted in
 REQUEST_DETAIL_URL = os.getenv('REQUEST_DETAIL_URL', '')  # use {request_id} to have it substituted in
 SCIENCE_APPLICATION_DETAIL_URL = os.getenv('SCIENCE_APPLICATION_DETAIL_URL', '')  # use {scicapp_id} to have it substituted in

--- a/observation_portal/settings.py
+++ b/observation_portal/settings.py
@@ -253,7 +253,7 @@ OPENSEARCH_URL = os.getenv('OPENSEARCH_URL', 'http://localhost')
 CONFIGDB_URL = os.getenv('CONFIGDB_URL', 'http://localhost')
 DOWNTIMEDB_URL = os.getenv('DOWNTIMEDB_URL', 'http://localhost')
 
-# Real time session booking variables for availiability
+# Real time session booking variables for availability
 # Availability from (current time + minutes in) to (current time + minutes in + days out)
 REAL_TIME_AVAILABILITY_DAYS_OUT = int(os.getenv('REAL_TIME_AVAILABILITY_DAYS_OUT', 7))
 REAL_TIME_AVAILABILITY_MINUTES_IN = int(os.getenv('REAL_TIME_AVAILABILITY_MINUTES_IN', 60))


### PR DESCRIPTION
Basic availability endpoint that takes night time and downtime to generate availability intervals for all telescopes that a users proposals have time on. 