### PR TITLE
Allow staff users to circumvent realtime availability per telescope r…

### DIFF
--- a/observation_portal/observations/realtime.py
+++ b/observation_portal/observations/realtime.py
@@ -119,7 +119,7 @@ def get_realtime_availability(user: User, telescope_filter: str = ''):
 
     for resource in telescopes_availability.keys():
         telescope, enclosure, site = resource.split('.')
-        intervals = filtered_dark_intervalset_for_telescope(start, end, site, enclosure, telescope)
+        intervals = filtered_dark_intervalset_for_telescope(user, start, end, site, enclosure, telescope)
         intervals_to_block = []
         # Now also filter out running obs, future high priority (TC, RR, Direct) obs, and obs overlapping in time by the user
         if resource in in_progress_intervals:

--- a/observation_portal/observations/serializers.py
+++ b/observation_portal/observations/serializers.py
@@ -419,6 +419,7 @@ class RealTimeSerializer(serializers.ModelSerializer):
         # Validate that the start/end time is during nighttime at the telescope
         # Also check that there is not an overlapping downtime
         interval_available = is_realtime_interval_available_for_telescope(
+            user,
             validated_data['start'],
             validated_data['end'],
             validated_data['site'],


### PR DESCRIPTION
…estrictions

This ignores the special per-telescope blocking of realtime time windows if the user is staff.