### PR TITLE
Plumbed error strings through for full configuration validation schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim as base
+FROM python:3.10-slim AS base
 
 # these commands are organized to minimize docker build cache invalidation
 # (barring any other logical constraints)
@@ -38,7 +38,7 @@ ENV PATH="/src/.venv/bin:$PATH" PYTHONUNBUFFERED=1 PYTHONFAULTHANDLER=1
 # usefull for running tests in docker container
 # this won't be included in the final image
 # e.g. docker build --target dev .
-FROM base as dev
+FROM base AS dev
 
 RUN poetry install --only dev
 
@@ -46,7 +46,7 @@ ENTRYPOINT ["bash"]
 
 
 # final image
-FROM base as prod
+FROM base AS prod
 
 # add a non-root user to run the app
 RUN useradd appuser

--- a/observation_portal/common/test_data/configdb.json
+++ b/observation_portal/common/test_data/configdb.json
@@ -2448,6 +2448,25 @@
                           "offset_ra": {"type": "float"},
                           "offset_dec": {"type": "float"}
                         }
+                      },
+                      "target": {
+                        "schema": {
+                          "dec": {
+                            "max": 85.0,
+                            "min": -85.0,
+                            "type": "float"
+                          }
+                        },
+                        "type": "dict"
+                      },
+                      "constraints": {
+                        "schema": {
+                          "max_airmass": {
+                            "min": 2.0,
+                            "type": "float"
+                          }
+                        },
+                        "type": "dict"
                       }
                     }
                   },

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 class ValidationHelper(ABC):
+    CONFIG_SECTIONS = ['guiding_config', 'acquisition_config', 'target', 'constraints']
     """Base class for validating documents"""
     @abstractmethod
     def __init__(self):
@@ -85,6 +86,14 @@ class ValidationHelper(ABC):
         serializer_errors = {}
         if 'extra_params' in validation_errors:
             serializer_errors['extra_params'] = validation_errors['extra_params'][0]
+        for section in self.CONFIG_SECTIONS:
+            if section in validation_errors:
+                error = validation_errors[section][0]
+                if section not in serializer_errors:
+                    serializer_errors[section] = {}
+                serializer_errors[section].update(error)
+                if 'extra_params' in error:
+                    serializer_errors[section]['extra_params'] = error['extra_params'][0]
         if 'instrument_configs' in validation_errors:
             instrument_configs_errors = []
             last_instrument_config_with_error = max(validation_errors['instrument_configs'][0].keys())


### PR DESCRIPTION
The main change here allows the error to be converted from cerberus validation error format to django rest framework error format, so it shows up on the proper field erroring on the UI. 

This will allow [this issue](https://lcoglobal.redmineup.com/issues/2704) to be resolved by adding some code to the cerberus validation_schema for the nres instrument type in configdb. It is currently in the dev configdb and looks to be working will with this change.