### PR TITLE
Fix error in user authentication and block porting sci applications w…

### DIFF
--- a/observation_portal/accounts/backends.py
+++ b/observation_portal/accounts/backends.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 class EmailOrUsernameModelBackend(object):
     @staticmethod
     def authenticate(request, username=None, password=None):
-        if '@' in username:
+        if username and '@' in username:
             kwargs = {'email': username}
         else:
             kwargs = {'username': username}

--- a/observation_portal/accounts/test_views.py
+++ b/observation_portal/accounts/test_views.py
@@ -77,6 +77,39 @@ class TestIndex(TestCase):
         user = auth.get_user(self.client)
         self.assertTrue(user.is_authenticated)
 
+    def test_api_login_missing_password(self):
+        response = self.client.post(
+            reverse('api_login'),
+            data=json.dumps({'username': 'doge'}),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['message'], 'Must provide a `username` and `password`')
+        user = auth.get_user(self.client)
+        self.assertFalse(user.is_authenticated)
+
+    def test_api_login_missing_username(self):
+        response = self.client.post(
+            reverse('api_login'),
+            data=json.dumps({'password': 'sopassword'}),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['message'], 'Must provide a `username` and `password`')
+        user = auth.get_user(self.client)
+        self.assertFalse(user.is_authenticated)
+
+    def test_api_login_missing_username_and_password(self):
+        response = self.client.post(
+            reverse('api_login'),
+            data=json.dumps({}),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['message'], 'Must provide a `username` and `password`')
+        user = auth.get_user(self.client)
+        self.assertFalse(user.is_authenticated)
+
     def test_login_with_email(self):
         self.client.post(
             reverse('auth_login'),

--- a/observation_portal/accounts/views.py
+++ b/observation_portal/accounts/views.py
@@ -178,6 +178,10 @@ class ApiLoginView(APIView):
     def post(self, request):
         username = request.data.get('username')
         password = request.data.get('password')
+        if username is None or password is None:
+            return Response(
+                {"message": "Must provide a `username` and `password`"}, status=status.HTTP_400_BAD_REQUEST
+            )
         user = authenticate(request, username=username, password=password)
         if user is not None:
             if (

--- a/observation_portal/sciapplications/admin.py
+++ b/observation_portal/sciapplications/admin.py
@@ -13,7 +13,8 @@ from observation_portal.common.admin import export_sciapps_key_data_tsv
 from observation_portal.sciapplications.models import (
     Instrument, Call, ScienceApplication, TimeRequest, CoInvestigator,
     NoTimeAllocatedError, MultipleTimesAllocatedError, ScienceApplicationReview,
-    ScienceApplicationUserReview, ReviewPanel, ReviewPanelMembership
+    ScienceApplicationUserReview, ReviewPanel, ReviewPanelMembership,
+    NoPrioritySetError
 )
 from observation_portal.proposals.models import Proposal
 from observation_portal.common.utils import get_queryset_field_values
@@ -124,6 +125,11 @@ class ScienceApplicationAdmin(admin.ModelAdmin):
             else:
                 try:
                     app.convert_to_proposal()
+                except NoPrioritySetError:
+                    self.message_user(
+                        request, f'Application {app.title} has no Tac Priority set', level='ERROR'
+                    )
+                    return
                 except NoTimeAllocatedError:
                     self.message_user(
                         request, f'Application {app.title} has no approved Time Allocations', level='ERROR'

--- a/observation_portal/sciapplications/models.py
+++ b/observation_portal/sciapplications/models.py
@@ -28,6 +28,10 @@ class MultipleTimesAllocatedError(Exception):
     pass
 
 
+class NoPrioritySetError(Exception):
+    pass
+
+
 class Instrument(models.Model):
     code = models.CharField(max_length=50)
     display = models.CharField(max_length=50)
@@ -189,6 +193,9 @@ class ScienceApplication(models.Model):
             return reverse('api:scienceapplications-detail', args=(self.id,))
 
     def convert_to_proposal(self):
+        if self.tac_priority == 0:
+            raise NoPrioritySetError
+
         approved_time_requests = self.timerequest_set.filter(approved=True)
         if not approved_time_requests.count():
             raise NoTimeAllocatedError

--- a/observation_portal/sciapplications/test_admin.py
+++ b/observation_portal/sciapplications/test_admin.py
@@ -44,7 +44,8 @@ class TestSciAppAdmin(DramatiqTestCase):
             status=ScienceApplication.SUBMITTED,
             submitter=self.user,
             call=self.call,
-            tac_rank=(x for x in range(3))
+            tac_rank=(x for x in range(3)),
+            tac_priority=(x+1 for x in range(3))
         )
         mixer.cycle(3).blend(
             TimeRequest,

--- a/observation_portal/sciapplications/tests.py
+++ b/observation_portal/sciapplications/tests.py
@@ -6,7 +6,7 @@ from django_dramatiq.test import DramatiqTestCase
 from django.utils import timezone
 
 from observation_portal.accounts.test_utils import blend_user
-from observation_portal.sciapplications.models import ScienceApplication, Call, TimeRequest, CoInvestigator, Instrument, ScienceApplicationReview, ReviewPanel
+from observation_portal.sciapplications.models import ScienceApplication, Call, TimeRequest, CoInvestigator, Instrument, ScienceApplicationReview, ReviewPanel, NoPrioritySetError
 from observation_portal.proposals.models import Semester, Membership, ProposalInvite, ScienceCollaborationAllocation
 
 
@@ -105,6 +105,12 @@ class TestSciAppToProposal(TestCase):
 
         self.assertEqual(proposal.timeallocation_set.get(semester=other_semester).std_allocation, tr2.std_time)
         self.assertEqual(proposal.timeallocation_set.get(semester=other_semester).instrument_types[0], it2.code)
+
+    def test_convert_to_proposal_without_priority_raises(self):
+        app = mixer.blend(ScienceApplication, submitter=self.user, pi='', tac_priority=0)
+        mixer.blend(TimeRequest, approved=True, science_application=app)
+        with self.assertRaises(NoPrioritySetError):
+            app.convert_to_proposal()
 
     def test_create_collab_proposal(self):
         pi = blend_user()

--- a/observation_portal/sciapplications/tests.py
+++ b/observation_portal/sciapplications/tests.py
@@ -21,7 +21,7 @@ class TestSciAppToProposal(TestCase):
         )
 
     def test_create_proposal_from_single_pi(self):
-        app = mixer.blend(ScienceApplication, submitter=self.user, pi='')
+        app = mixer.blend(ScienceApplication, submitter=self.user, pi='', tac_priority=1)
         it = mixer.blend(Instrument)
         tr = mixer.blend(TimeRequest, approved=True, science_application=app, instrument_types=[it])
         proposal = app.convert_to_proposal()
@@ -32,7 +32,7 @@ class TestSciAppToProposal(TestCase):
         self.assertFalse(ProposalInvite.objects.filter(proposal=proposal).exists())
 
     def test_create_proposal_with_supplied_noexistant_pi(self):
-        app = mixer.blend(ScienceApplication, submitter=self.user, pi='frodo@example.com')
+        app = mixer.blend(ScienceApplication, submitter=self.user, pi='frodo@example.com', tac_priority=1)
         tr = mixer.blend(TimeRequest, approved=True, science_application=app)
         proposal = app.convert_to_proposal()
         self.assertEqual(app.proposal, proposal)
@@ -42,7 +42,7 @@ class TestSciAppToProposal(TestCase):
 
     def test_create_proposal_with_supplied_existant_pi(self):
         user = blend_user()
-        app = mixer.blend(ScienceApplication, submitter=self.user, pi=user.email)
+        app = mixer.blend(ScienceApplication, submitter=self.user, pi=user.email, tac_priority=1)
         tr = mixer.blend(TimeRequest, approved=True, science_application=app)
         proposal = app.convert_to_proposal()
         self.assertEqual(app.proposal, proposal)
@@ -52,7 +52,7 @@ class TestSciAppToProposal(TestCase):
 
     def test_create_proposal_with_tags(self):
         user = blend_user()
-        app = mixer.blend(ScienceApplication, submitter=self.user, pi=user.email)
+        app = mixer.blend(ScienceApplication, submitter=self.user, pi=user.email, tac_priority=1)
         tr = mixer.blend(TimeRequest, approved=True, science_application=app)
         proposal = app.convert_to_proposal()
         self.assertEqual(app.proposal, proposal)
@@ -63,7 +63,7 @@ class TestSciAppToProposal(TestCase):
         self.assertTrue(len(proposal.tags) == 0)
 
     def test_create_proposal_with_nonexistant_cois(self):
-        app = mixer.blend(ScienceApplication, submitter=self.user, pi='')
+        app = mixer.blend(ScienceApplication, submitter=self.user, pi='', tac_priority=1)
         mixer.cycle(3).blend(CoInvestigator, science_application=app)
         tr = mixer.blend(TimeRequest, approved=True, science_application=app)
         proposal = app.convert_to_proposal()
@@ -73,7 +73,7 @@ class TestSciAppToProposal(TestCase):
         self.assertEqual(ProposalInvite.objects.filter(proposal=proposal).count(), 3)
 
     def test_create_proposal_with_existant_cois(self):
-        app = mixer.blend(ScienceApplication, submitter=self.user, pi='')
+        app = mixer.blend(ScienceApplication, submitter=self.user, pi='', tac_priority=1)
         coi1 = blend_user(user_params={'email': '1@example.com'})
         coi2 = blend_user(user_params={'email': '2@example.com'})
         mixer.blend(CoInvestigator, email='1@example.com', science_application=app)
@@ -90,7 +90,7 @@ class TestSciAppToProposal(TestCase):
 
     def test_create_key_proposal_multiple_semesters(self):
         other_semester = mixer.blend(Semester)
-        app = mixer.blend(ScienceApplication, submitter=self.user, pi='')
+        app = mixer.blend(ScienceApplication, submitter=self.user, pi='', tac_priority=1)
         it = mixer.blend(Instrument)
         it2 = mixer.blend(Instrument)
         tr = mixer.blend(TimeRequest, approved=True, science_application=app, instrument_types=[it], semester=self.semester)
@@ -116,7 +116,7 @@ class TestSciAppToProposal(TestCase):
         pi = blend_user()
         submitter = blend_user()
         sca = mixer.blend(ScienceCollaborationAllocation, admin=submitter)
-        app = mixer.blend(ScienceApplication, submitter=submitter, pi=pi.email)
+        app = mixer.blend(ScienceApplication, submitter=submitter, pi=pi.email, tac_priority=1)
         tr = mixer.blend(TimeRequest, approved=True, science_application=app)
         proposal = app.convert_to_proposal()
         self.assertEqual(app.proposal, proposal)


### PR DESCRIPTION
…ith zero tac priority

The user api login error message is because I noticed some 500 error emails where someone was hitting it with no username/password, which crashed things. This should return a 400 error if they leave out those fields instead of crash.

The sciapp part is a simple change to display an error in the admin interface if they try to run the port action without setting tac priority to a non-zero value first.